### PR TITLE
Runs composer install inside of the cli container if the vendor directory does not exist.

### DIFF
--- a/bin/dktl.sh
+++ b/bin/dktl.sh
@@ -66,6 +66,10 @@ elif [ "$1" = "docker:surl" ]; then
 elif [ "$1" = "drush" ]; then
     $BASE_DOCKER_COMPOSE_COMMAND exec cli php /usr/local/dkan-tools/bin/app.php $1 -- "${@:2}" --uri=`dktl docker:surl`
 else
+    VENDOR="$($BASE_DOCKER_COMPOSE_COMMAND exec cli ls -lha /usr/local/dkan-tools | grep vendor)"
+    if [ -z "$VENDOR" ]; then
+        $BASE_DOCKER_COMPOSE_COMMAND exec cli composer install --working-dir=/usr/local/dkan-tools/
+    fi
     $BASE_DOCKER_COMPOSE_COMMAND exec cli php /usr/local/dkan-tools/bin/app.php $1 "${@:2}"
 fi
 


### PR DESCRIPTION
Fixes #6

**QA**
- dktl dc up -d
- dktl (composer install should run)
- dktl (composer should not run again)