### PR TITLE
Make chown behavior optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,10 @@ Everything else is flexible:
 
 Each function inside of the class will show up as an available DKTL command.
 
-_More documentation coming soon!_
+## Disabling CHOWN
+
+DKTL, by default, performs most of its tasks inside of a docker container. This can cause project files to have undesirable permissions. To combat that, DKTL attempts to give ownership of all project files to the user running DKTL when it detects that files have changed. In some circumstances we do not want this behavior. This can be controlled through and environment variable.
+
+To disable chowning create the environment variable with this command:
+
+```export DKTL_CHOWN="FALSE"```

--- a/README.md
+++ b/README.md
@@ -163,10 +163,12 @@ Everything else is flexible:
 
 Each function inside of the class will show up as an available DKTL command.
 
-## Disabling CHOWN
+## Disabling `chown`
 
-DKTL, by default, performs most of its tasks inside of a docker container. This can cause project files to have undesirable permissions. To combat that, DKTL attempts to give ownership of all project files to the user running DKTL when it detects that files have changed. In some circumstances we do not want this behavior. This can be controlled through and environment variable.
+DKTL, by default, performs most of its tasks inside of a docker container. The result is that any files created by scripts running inside the container will appear to be owned by "root" on the host machine, which often leads to permission issues when trying to use these files. To avoid this DKTL attempts to give ownership of all project files to the user running DKTL when it detects that files have changed, using the `chown` command via `sudo`. In some circumstances, such as environments where `sudo` is not available, you may not want this behavior. This can be controlled by setting a true/false environment variable, `DKTL_CHOWN`.
 
-To disable chowning create the environment variable with this command:
+To disable the chown behavior, create the environment variable with this command:
 
-```export DKTL_CHOWN="FALSE"```
+```bash
+export DKTL_CHOWN="FALSE"
+```

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Each function inside of the class will show up as an available DKTL command.
 
 DKTL, by default, performs most of its tasks inside of a docker container. The result is that any files created by scripts running inside the container will appear to be owned by "root" on the host machine, which often leads to permission issues when trying to use these files. To avoid this DKTL attempts to give ownership of all project files to the user running DKTL when it detects that files have changed, using the `chown` command via `sudo`. In some circumstances, such as environments where `sudo` is not available, you may not want this behavior. This can be controlled by setting a true/false environment variable, `DKTL_CHOWN`.
 
-To disable the chown behavior, create the environment variable with this command:
+To disable the `chown` behavior, create the environment variable with this command:
 
 ```bash
 export DKTL_CHOWN="FALSE"

--- a/bin/dktl.sh
+++ b/bin/dktl.sh
@@ -89,9 +89,11 @@ else
     $BASE_DOCKER_COMPOSE_COMMAND exec cli dktl $1 "${@:2}"
 fi
 
-# Docker creates files that appear as owned by root on host. Fix:
-if [ ! -z `find $DKTL_PROJECT_DIRECTORY -user root -print -quit` ]; then
-    CHOWN_CMD="sudo chown -R $USER:$USER $DKTL_PROJECT_DIRECTORY"
-    echo && echo "➜  Changing ownership of new files to host user"
-    echo -e "\e[32m$CHOWN_CMD\e[39m" && $CHOWN_CMD
+if [ -z $DKTL_CHOWN ] || [ "$DKTL_CHOWN" = "TRUE" ]; then
+    # Docker creates files that appear as owned by root on host. Fix:
+    if [ ! -z `find $DKTL_PROJECT_DIRECTORY -user root -print -quit` ]; then
+        CHOWN_CMD="sudo chown -R $USER:$USER $DKTL_PROJECT_DIRECTORY"
+        echo && echo "➜  Changing ownership of new files to host user"
+        echo -e "\e[32m$CHOWN_CMD\e[39m" && $CHOWN_CMD
+    fi
 fi


### PR DESCRIPTION
Connects #10 

**QA**
- Try `dktl dkan:get`, chown should happen
- Create the environment variable `export DKTL_CHOWN="FALSE"`, chown should not happen
- Modify variable `export DKTL_CHOWN="TRUE"`, chown should happen again