### PR TITLE
Use Robo/Result to eliminate ambiguity

### DIFF
--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -2,6 +2,7 @@
 
 namespace DkanTools\Command;
 
+use Robo\Result;
 use DkanTools\Util\Util;
 
 /**


### PR DESCRIPTION
Fixes a bug that appeared on a `dktl init` command, where namespacing for `Result` class was ambiguous.

![image](https://user-images.githubusercontent.com/309671/46755499-3702f680-cc93-11e8-9d6f-e092fc274c43.png)
