### PR TITLE
Switch to php7-web container

### DIFF
--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   web:
     hostname: web
-    image: nuams/drupal-apache-php:1.0-5.6
+    image: getdkan/dkan-docker:php7-web
     ports:
       - "80"
       - "443"

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -152,10 +152,14 @@ class DkanCommands extends \Robo\Tasks
      * @param string $files_url
      *   A url to an archive with all the files to the site. zip, gz, and tar.gz files are supported.
      */
-    public function dkanRestore($db_url, $files_url)
+    public function dkanRestore($db_url = NULL, $files_url = NULL)
     {
-        $this->restoreDb($db_url);
-        $this->restoreFiles($files_url);
+        if ($db_url) {
+          $this->restoreDb($db_url);
+        }
+        if ($files_url) {
+          $this->restoreFiles($files_url);
+        }
     }
 
     private function restoreDb($db_url)


### PR DESCRIPTION
Also adds a tweak to the restore command to make arguments optional. This lets me, for instance, comment out one of the arguments from my dktl.yml file to skip the files restore, without having to change DKTL code if I want to skip that for now.