### PR TITLE
Throw exception and exit if error on getFile()

### DIFF
--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -334,12 +334,12 @@ class DkanCommands extends \Robo\Tasks
 
         if ($result->getExitCode() == 0) {
             $this->io()->success("Got the file from {$url}.");
+            return "$tmp_dir_path/$filename";
         }
         else {
             $this->io()->error("Issues getting the file from {$url}.");
+            throw new \Exception("Error retrieving file.");
         }
-
-        return "$tmp_dir_path/$filename";
     }
 
     private function dkanTempReplace($tmp_dkan)


### PR DESCRIPTION
The `dkan:restore` command would keep trying to do stuff even after a download failed:

![image](https://user-images.githubusercontent.com/309671/49397044-910ac000-f708-11e8-9727-74ce128c1ac0.png)

This PR nips that problem in the bud.

## QA Steps

1. Check out this branch of dkan-tools
2. Temporarily remove your aws credntials
3. Check out a fresh copy of a site and attempt a `dkan:restore`. Rather than the output above, you should just see:

![image](https://user-images.githubusercontent.com/309671/49545264-1d54e880-f8ab-11e8-83d6-cd6848111d88.png)
