### PR TITLE
Add trailing slash to aws cp command

### DIFF
--- a/src/Command/RestoreCommands.php
+++ b/src/Command/RestoreCommands.php
@@ -214,7 +214,7 @@ class RestoreCommands extends \Robo\Tasks
             $parser = new \Aws\S3\S3UriParser();
             $info = $parser->parse($url);
             $filename = $info['key'];
-            $approach = "aws s3 cp {$url} {$tmp_dir_path}";
+            $approach = "aws s3 cp {$url} {$tmp_dir_path}/";
         }
         else {
             $this->io()->error("Unsupported file protocol.");


### PR DESCRIPTION
I'm not sure why this suddenly started breaking but have been getting errors because the path was ambiguous. 