### PR TITLE
Validate make yaml before running make commands

### DIFF
--- a/src/Drupal/V7/MakeCommands.php
+++ b/src/Drupal/V7/MakeCommands.php
@@ -2,6 +2,7 @@
 namespace DkanTools\Drupal\V7;
 
 use DkanTools\Util\Util;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * This is project's console commands configuration for Robo task runner.
@@ -40,7 +41,11 @@ class MakeCommands extends \Robo\Tasks
     public function makeProfile($opts = ['yes|y' => false])
     {
       if (file_exists('dkan/modules/contrib')) {
-          if (!$opts['yes|y'] && !$this->io()->confirm('DKAN dependencies have already been dowloaded. Would you like to delete and dowload them again?')) {
+          if (!Yaml::parse(file_get_contents(Util::getProjectDirectory() . '/src/make/dkan.make'))) {
+              return false;
+          }
+          $confirmText = 'DKAN dependencies have already been dowloaded. Would you like to delete and dowload them again?';
+          if (!$opts['yes|y'] && !$this->io()->confirm($confirmText)) {
               $this->io()->warning('Make aborted');
               return false;
           }
@@ -76,6 +81,9 @@ class MakeCommands extends \Robo\Tasks
     {
         if (!file_exists('dkan')) {
             throw \Exception('We need DKAN before making Drupal');
+            return false;
+        }
+        if (!Yaml::parse(file_get_contents(Util::getProjectDirectory() . '/src/make/dkan.make'))) {
             return false;
         }
         if (file_exists('docroot')) {


### PR DESCRIPTION
This solves a minor problem where the make command is run without validating the files in  src/make first. If you have invalid yaml in there, the command would remove the profile directories but then fail, leaving you with a broken codebase. This fix will not allow the dkan dirs to be deleted unless the make yaml files are valid yaml.