### PR TITLE
Fix some minor error handling issues with make and dkan:get

### DIFF
--- a/src/Drupal/V7/DkanCommands.php
+++ b/src/Drupal/V7/DkanCommands.php
@@ -69,8 +69,8 @@ class DkanCommands extends \Robo\Tasks
         }
 
         if (!isset($source)) {
-            $this->io()->error("No archive available for DKAN $version.");
-            return;
+            throw new \Exception("No archive available for DKAN $version.");
+            return false;
         }
 
         $this->io()->section("Getting DKAN from {$source}");

--- a/src/Drupal/V7/MakeCommands.php
+++ b/src/Drupal/V7/MakeCommands.php
@@ -27,8 +27,11 @@ class MakeCommands extends \Robo\Tasks
         $yes = (isset($opts['yes|y'])) ? $opts['yes|y'] : false;
         $make_opts = ['yes|y' => $yes];
 
-        $this->makeProfile($make_opts);
-        $this->makeDrupal($opts);
+        $result = $this->makeProfile($make_opts);
+        if ($result->getExitCode() === 0) {
+            $result = $this->makeDrupal($opts);
+        }
+        return $result;
     }
 
     /**
@@ -39,29 +42,31 @@ class MakeCommands extends \Robo\Tasks
     */
     public function makeProfile($opts = ['yes|y' => false])
     {
-      if (file_exists('dkan/modules/contrib')) {
-          if (!$opts['yes|y'] && !$this->io()->confirm('DKAN dependencies have already been dowloaded. Would you like to delete and dowload them again?')) {
-              $this->io()->warning('Make aborted');
-              return false;
-          }
-          $this->_deleteDir([
-              'dkan/modules/contrib',
-              'dkan/themes/contrib',
-              'dkan/libraries'
-          ]);
-      }
+        if (file_exists('dkan/modules/contrib')) {
+            if (!$opts['yes|y'] && !$this->io()->confirm('DKAN dependencies have already been dowloaded. Would you like to delete and dowload them again?')) {
+                $this->io()->warning('Make aborted');
+                return false;
+            }
+            $this->_deleteDir([
+                'dkan/modules/contrib',
+                'dkan/themes/contrib',
+                'dkan/libraries'
+            ]);
+        }
 
-      $this->taskExec('drush -y make dkan/drupal-org.make')
-          ->arg('--contrib-destination=./')
-          ->arg('--no-core')
-          ->arg('--root=docroot')
-          ->arg('--no-recursion')
-          ->arg('--no-cache')
-          ->arg('--verbose')
-          ->arg('--overrides=src/make/dkan.make')
-          ->arg('--concurrency=' . Util::drushConcurrency())
-          ->arg('dkan')
-          ->run();
+        $result = $this->taskExec('drush -y make dkan/drupal-org.make')
+            ->arg('--contrib-destination=./')
+            ->arg('--no-core')
+            ->arg('--root=docroot')
+            ->arg('--no-recursion')
+            ->arg('--no-cache')
+            ->arg('--verbose')
+            ->arg('--overrides=src/make/dkan.make')
+            ->arg('--concurrency=' . Util::drushConcurrency())
+            ->arg('dkan')
+            ->run();
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
1. `dktl dkan:get` would still try to proceed even if version was not available.
![image](https://user-images.githubusercontent.com/309671/51980645-ae38e200-245e-11e9-88f6-c6bca44963f4.png)

2. `dktl make` would proceed to Drupal make even if DKAN make failed due to bad yaml.
