### PR TITLE
Add -f to readlink command to get correct $DKTL_DIRECTORY

### DIFF
--- a/bin/dktl
+++ b/bin/dktl
@@ -51,7 +51,7 @@ export DKTL_PROJECT_DIRECTORY
 
 DKTL_DIRECTORY=$(which dktl)
 if [[ -L $(which dktl) ]]; then
-  DKTL_DIRECTORY=$(readlink $DKTL_DIRECTORY)
+  DKTL_DIRECTORY=$(readlink -f $DKTL_DIRECTORY)
 fi
 DKTL_DIRECTORY=$(dirname $(dirname $DKTL_DIRECTORY))
 export DKTL_DIRECTORY


### PR DESCRIPTION
Without `-f`, the dktl command will not detect the true location of the dkan-tools root directory correctly and the docker command will fail (looking for docker-compose.common.yml in the wrong place). This ensures that `$DKTL_DIRECTORY` is an absolute path.

From the `readlink` man:
> **-f, --canonicalize**
>>    canonicalize by following every symlink in every component of the given name recursively; all but the last component must exist 

## QA Test

1. Check out the branch, and make sure the `dktl` command works from any subdir of the project.
2. For full QA, do something like what I have set up for my dktl path: install dkan-tools at _~/Work/dkan-tools_ (or a similar path in your home), add a symlink to _~/Work/dkan-tools/bin in ~/.local/bin (and make sure the latter is in your `$PATH`). 
3. Try `dktl` from various dirs within your project.


![image](https://user-images.githubusercontent.com/309671/52746218-04ee0200-2faf-11e9-90b0-3a13dceff096.png)
