### PR TITLE
Cleanup url and add uli commands

### DIFF
--- a/bin/dktl
+++ b/bin/dktl
@@ -93,11 +93,17 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
   if [ "$1" = "docker:compose" ] || [ "$1" = "dc" ]; then
     $BASE_DOCKER_COMPOSE_COMMAND ${@:2}
     exit 0
-  elif [ "$1" = "docker:url" ]; then
+  elif [ "$1" = "url" ] || [ "$1" = "docker:url" ]; then
     echo "http://$PROXY_DOMAIN:$($BASE_DOCKER_COMPOSE_COMMAND port web 80|cut -d ':' -f2)"
     exit 0
-  elif [ "$1" = "docker:surl" ]; then
+  elif [ "$1" = "surl" ] || [ "$1" = "docker:surl" ]; then
     echo "https://$PROXY_DOMAIN:$($BASE_DOCKER_COMPOSE_COMMAND port web 443|cut -d ':' -f2)"
+    exit 0
+  elif [ "$1" = "uli" ]; then
+    dktl drush uli --uri=`dktl url`
+    exit 0
+  elif [ "$1" = "suli" ]; then
+    dktl drush uli --uri=`dktl surl`
     exit 0
   fi
   

--- a/src/Command/DockerCommands.php
+++ b/src/Command/DockerCommands.php
@@ -34,9 +34,9 @@ class DockerCommands extends \Robo\Tasks
     }
 
     /**
-     * Display the web URL for the current project.
+     * Display the insecure (http) web URL for the current project.
      */
-    public function dockerUrl()
+    public function url()
     {
         throw new \Exception(DKTL_DOCKER_PHP_ERROR);
     }
@@ -44,7 +44,23 @@ class DockerCommands extends \Robo\Tasks
     /**
      * Display the secure (https) web URL for the current project.
      */
-    public function dockerSurl()
+    public function surl()
+    {
+        throw new \Exception(DKTL_DOCKER_PHP_ERROR);
+    }
+
+    /**
+     * Show clickable admin login link for insecure web URL (http)
+     */
+    public function uli()
+    {
+        throw new \Exception(DKTL_DOCKER_PHP_ERROR);
+    }
+
+    /**
+     * Show clickable admin login link for secure URL (https)
+     */
+    public function suli()
     {
         throw new \Exception(DKTL_DOCKER_PHP_ERROR);
     }


### PR DESCRIPTION
Clean up the url and uri commands a bit. While the old ones are still suported, we now have:

`dktl surl` - the secure url for the current dktl project
`dktl url` - the insecure url for the current dktl project
`dktl suli` - open a password reset link (`drush uli`) with the correct secure url
`dktl uli` - open a password reset link (`drush uli`) with the correct insecure url

I considered the possibility of just having `url/uli` and using the secure url there, since personally I have no use for the insecure url and don't see any utility for having it available. But I opted for this to be on the safe side. LMK if you think I should have gone with that option.