### PR TITLE
Docker compose error

### DIFF
--- a/bin/dktl
+++ b/bin/dktl
@@ -123,7 +123,7 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
   fi
 
   # The containers are running, set DKTL inside the cli container.
-  ALIAS="$($BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS which dktl)"
+  ALIAS="$($BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli which dktl)"
   if [ -z "$ALIAS" ]; then
     $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli chmod 777 /usr/local/dkan-tools/bin/dktl
     $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli ln -s /usr/local/dkan-tools/bin/dktl /usr/local/bin/dktl

--- a/bin/dktl
+++ b/bin/dktl
@@ -87,9 +87,7 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
     BASE_DOCKER_COMPOSE_COMMAND+=" -f $OVERRIDES_CONF"
   fi
   # Check for interactive shell
-  # REMIND - under circle ci, we also seem to need -T; hardwire for the moment
-  EXEC_OPTS='-T'
-  # if [ -t 1 ]; then EXEC_OPTS='-T'; else EXEC_OPTS='-T'; fi
+  if [ -t 1 ]; then EXEC_OPTS='-it'; else EXEC_OPTS=''; fi
 
   # Run docker commands immediately then exit
   if [ "$1" = "docker:compose" ] || [ "$1" = "dc" ]; then
@@ -116,15 +114,21 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
     $BASE_DOCKER_COMPOSE_COMMAND up -d
   fi
 
+  cli_container=$($BASE_DOCKER_COMPOSE_COMMAND ps -q cli)
+  BASE_DOCKER_EXEC_COMMAND="docker exec $EXEC_OPTS $cli_container"
+  
   # The containers are running, set DKTL inside the cli container.
-  ALIAS="$($BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli which dktl)"
+  ALIAS="$(docker exec $cli_container which dktl)"
   if [ -z "$ALIAS" ]; then
-      $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli chmod 777 /usr/local/dkan-tools/bin/dktl
-      $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli ln -s /usr/local/dkan-tools/bin/dktl /usr/local/bin/dktl
+      $BASE_DOCKER_EXEC_COMMAND chmod 777 /usr/local/dkan-tools/bin/dktl
+      $BASE_DOCKER_EXEC_COMMAND ln -s /usr/local/dkan-tools/bin/dktl /usr/local/bin/dktl
+#      $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli chmod 777 /usr/local/dkan-tools/bin/dktl
+#      $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli ln -s /usr/local/dkan-tools/bin/dktl /usr/local/bin/dktl
   fi
 
   # Proxy pass to internal DKTL and save exit status
-  $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli env DRUPAL_VERSION=$DRUPAL_VERSION dktl $1 "${@:2}"
+  $BASE_DOCKER_EXEC_COMMAND env DRUPAL_VERSION=$DRUPAL_VERSION dktl $1 "${@:2}"
+#  $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli env DRUPAL_VERSION=$DRUPAL_VERSION dktl $1 "${@:2}"
   exit_status=$?
   
   # Reset web and cli containers if xdebug

--- a/bin/dktl
+++ b/bin/dktl
@@ -88,10 +88,7 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
   fi
 
   # Check for interactive shell if DKTL_NO_PTY is not set
-
-  if [ ! -z "$DKTL_NO_PTY" ]; then
-    EXEC_OPTS='-T'
-  elif [ -t 1 ]; then
+  if [ -z "$DKTL_NO_PTY" ] || [ -t 1 ]; then
     EXEC_OPTS=''
   else 
     EXEC_OPTS='-T';

--- a/bin/dktl
+++ b/bin/dktl
@@ -87,7 +87,9 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
     BASE_DOCKER_COMPOSE_COMMAND+=" -f $OVERRIDES_CONF"
   fi
   # Check for interactive shell
-  if [ -t 1 ]; then EXEC_OPTS=''; else EXEC_OPTS='-T'; fi
+  # REMIND - under circle ci, we also seem to need -T; hardwire for the moment
+  EXEC_OPTS='-T'
+  # if [ -t 1 ]; then EXEC_OPTS='-T'; else EXEC_OPTS='-T'; fi
 
   # Run docker commands immediately then exit
   if [ "$1" = "docker:compose" ] || [ "$1" = "dc" ]; then

--- a/bin/dktl
+++ b/bin/dktl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Set Drupal version if it isn't set.
 DRUPAL_VERSION=${DRUPAL_VERSION:-"V7"}
@@ -86,8 +86,10 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
   if [ -f $OVERRIDES_CONF ]; then
     BASE_DOCKER_COMPOSE_COMMAND+=" -f $OVERRIDES_CONF"
   fi
+
   # Check for interactive shell
-  if [ -t 1 ]; then EXEC_OPTS='-it'; else EXEC_OPTS='-t'; fi
+  EXEC_OPTS='-it'
+  # if [ -t 1 ]; then EXEC_OPTS='-it'; else EXEC_OPTS='-t'; fi
 
   # Run docker commands immediately then exit
   if [ "$1" = "docker:compose" ] || [ "$1" = "dc" ]; then
@@ -116,7 +118,7 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
 
   cli_container=$($BASE_DOCKER_COMPOSE_COMMAND ps -q cli)
   BASE_DOCKER_EXEC_COMMAND="docker exec $EXEC_OPTS $cli_container"
-  
+
   # The containers are running, set DKTL inside the cli container.
   ALIAS="$(docker exec $cli_container which dktl)"
   if [ -z "$ALIAS" ]; then

--- a/bin/dktl
+++ b/bin/dktl
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Set Drupal version if it isn't set.
 DRUPAL_VERSION=${DRUPAL_VERSION:-"V7"}
@@ -87,9 +87,15 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
     BASE_DOCKER_COMPOSE_COMMAND+=" -f $OVERRIDES_CONF"
   fi
 
-  # Check for interactive shell
-  EXEC_OPTS='-it'
-  # if [ -t 1 ]; then EXEC_OPTS='-it'; else EXEC_OPTS='-t'; fi
+  # Check for interactive shell if DKTL_NO_PTY is not set
+
+  if [ ! -z "$DKTL_NO_PTY" ]; then
+    EXEC_OPTS='-T'
+  elif [ -t 1 ]; then
+    EXEC_OPTS=''
+  else 
+    EXEC_OPTS='-T';
+  fi
 
   # Run docker commands immediately then exit
   if [ "$1" = "docker:compose" ] || [ "$1" = "dc" ]; then
@@ -116,21 +122,15 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
     $BASE_DOCKER_COMPOSE_COMMAND up -d
   fi
 
-  cli_container=$($BASE_DOCKER_COMPOSE_COMMAND ps -q cli)
-  BASE_DOCKER_EXEC_COMMAND="docker exec $EXEC_OPTS $cli_container"
-
   # The containers are running, set DKTL inside the cli container.
   ALIAS="$(docker exec $cli_container which dktl)"
   if [ -z "$ALIAS" ]; then
-      $BASE_DOCKER_EXEC_COMMAND chmod 777 /usr/local/dkan-tools/bin/dktl
-      $BASE_DOCKER_EXEC_COMMAND ln -s /usr/local/dkan-tools/bin/dktl /usr/local/bin/dktl
-#      $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli chmod 777 /usr/local/dkan-tools/bin/dktl
-#      $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli ln -s /usr/local/dkan-tools/bin/dktl /usr/local/bin/dktl
+    $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli chmod 777 /usr/local/dkan-tools/bin/dktl
+    $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli ln -s /usr/local/dkan-tools/bin/dktl /usr/local/bin/dktl
   fi
 
   # Proxy pass to internal DKTL and save exit status
-  $BASE_DOCKER_EXEC_COMMAND env DRUPAL_VERSION=$DRUPAL_VERSION dktl $1 "${@:2}"
-#  $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli env DRUPAL_VERSION=$DRUPAL_VERSION dktl $1 "${@:2}"
+  $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli env DRUPAL_VERSION=$DRUPAL_VERSION dktl $1 "${@:2}"
   exit_status=$?
   
   # Reset web and cli containers if xdebug

--- a/bin/dktl
+++ b/bin/dktl
@@ -123,7 +123,7 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
   fi
 
   # The containers are running, set DKTL inside the cli container.
-  ALIAS="$(docker exec $cli_container which dktl)"
+  ALIAS="$($BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS which dktl)"
   if [ -z "$ALIAS" ]; then
     $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli chmod 777 /usr/local/dkan-tools/bin/dktl
     $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli ln -s /usr/local/dkan-tools/bin/dktl /usr/local/bin/dktl

--- a/bin/dktl
+++ b/bin/dktl
@@ -87,7 +87,7 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
     BASE_DOCKER_COMPOSE_COMMAND+=" -f $OVERRIDES_CONF"
   fi
   # Check for interactive shell
-  if [ -t 1 ]; then EXEC_OPTS='-it'; else EXEC_OPTS=''; fi
+  if [ -t 1 ]; then EXEC_OPTS='-it'; else EXEC_OPTS='-t'; fi
 
   # Run docker commands immediately then exit
   if [ "$1" = "docker:compose" ] || [ "$1" = "dc" ]; then


### PR DESCRIPTION
If DKTL_NO_PTY is set, always pass -T to docker compose exec to make sure no pty is allocated.   Thi seems to help with running dktl in some CI pipelines, such as CircleCI.

Connects GetDKAN/dkan-tools#14