### PR TITLE
Add -y option to testQAUsers

### DIFF
--- a/src/Command/TestCommands.php
+++ b/src/Command/TestCommands.php
@@ -181,7 +181,7 @@ class TestCommands extends \Robo\Tasks
      * equal to the username.
      *
      * @option $workflow Create workflow users as well.
-     * @optoin $yes Use workflow option w/o checking for module.
+     * @option $yes Use workflow option w/o checking for module.
      */
     public function testQaUsers($opts = ['yes|y' => false, 'workflow|w' => false]) {
         $users = [

--- a/src/Command/TestCommands.php
+++ b/src/Command/TestCommands.php
@@ -181,15 +181,16 @@ class TestCommands extends \Robo\Tasks
      * equal to the username.
      *
      * @option $workflow Create workflow users as well.
+     * @optoin $yes Use workflow option w/o checking for module.
      */
-    public function testQaUsers($opts = ['workflow|w' => false]) {
+    public function testQaUsers($opts = ['yes|y' => false, 'workflow|w' => false]) {
         $users = [
             'sitemanager' => ['site manager'],
             'editor' => ['editor'],
             'creator' => ['content creator']
         ];
         if ($opts['workflow']) {
-            if ($this->hasWorkflow()) {
+            if ($this->hasWorkflow() || $opts['yes']) {
                 $users += [
                     'contributor' => ['content creator', 'Workflow Contributor'],
                     'moderator' => ['editor' , 'Workflow Moderator'],


### PR DESCRIPTION
This lets us override the check for the presence of `dkan_workflow_permissions` before running `dktl test:qa-users --workflow`. This is required for a project where we have the same workflow role names but using a custom module.

## QA Steps 
* Start with a site w/o dkan_workflow_permissions
* Create roles "Workflow Supervisor", "Workflow Moderator" and "Workflow Contributor"
* Run `dktl test:qa-users -w -y`. It should create six QA users.