### PR TITLE
Fix inconsistent return from MakeCommands::makeProfile

### DIFF
--- a/src/Drupal/V7/MakeCommands.php
+++ b/src/Drupal/V7/MakeCommands.php
@@ -28,11 +28,11 @@ class MakeCommands extends \Robo\Tasks
         $yes = (isset($opts['yes|y'])) ? $opts['yes|y'] : false;
         $make_opts = ['yes|y' => $yes];
 
-        $result = $this->makeProfile($make_opts);
-        if ($result->getExitCode() === 0) {
-            $result = $this->makeDrupal($opts);
+        $status = $this->makeProfile($make_opts);
+        if ($status) {
+            $status = $this->makeDrupal($opts);
         }
-        return $result;
+        return $status;
     }
 
     /**
@@ -67,7 +67,7 @@ class MakeCommands extends \Robo\Tasks
             ->arg('dkan')
             ->run();
 
-        return $result;
+        return $result->wasSuccessful();
     }
 
     /**


### PR DESCRIPTION
MakeCommands::makeProfile return a bool or a Robo\Result object which error off the
calling MakeCommands::make function with "Call to a member function
getExitCode() on bool".

![image](https://user-images.githubusercontent.com/1914306/55475706-8efc3380-560c-11e9-8c31-6f6a186f0c6d.png)

PR to unify the return type from `MakeCommands::makeProfile`

To QA, just run `dktl make` and no to `DKAN dependencies have already been dowloaded. Would you like to delete and dowload them again? (yes/no)`