### PR TITLE
Add hash salt and config sync directory to settings.php

### DIFF
--- a/assets/d8/site/settings.php
+++ b/assets/d8/site/settings.php
@@ -6,3 +6,6 @@ foreach (scandir(__DIR__) as $file) {
     include __DIR__ . "/{$file}";
   }
 }
+
+$config_directories['sync'] = '../config/sync';
+$settings['hash_salt'] = '{HASH_SALT}';

--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -25,6 +25,7 @@ services:
       # Linked containers to browser will also need this setting.
       - PROXY_DOMAIN
       - no_proxy=""
+      - DKTL_DOCKER=1
     env_file:
       - "${DKTL_DIRECTORY}/assets/docker/mysql.env"
 

--- a/src/Drupal/V8/InitCommands.php
+++ b/src/Drupal/V8/InitCommands.php
@@ -110,14 +110,23 @@ class InitCommands extends \Robo\Tasks
     private function createSettingsFiles($host = "")
     {
         $dktlRoot = Util::getDktlDirectory();
+        $hash_salt = Util::generateHashSalt(55);
 
         $settings = ["default.settings.php", "settings.php", "settings.docker.php"];
 
         foreach ($settings as $setting) {
             $f = "src/site/{$setting}";
-            $result = $this->taskWriteToFile($f)
+            if ($setting == 'settings.php') {
+              $result = $this->taskWriteToFile($f)
+                ->textFromFile("$dktlRoot/assets/d8/site/{$setting}")
+                ->place('HASH_SALT', $hash_salt)
+                ->run();
+            }
+            else {
+              $result = $this->taskWriteToFile($f)
                 ->textFromFile("$dktlRoot/assets/d8/site/{$setting}")
                 ->run();
+            }
             $this->directoryAndFileCreationCheck($result, $f);
         }
 

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -82,4 +82,11 @@ class Util
             exit;
         }
     }
+
+    /**
+     * Copy of \Drupal\Component\Utility\Crypt::randomBytesBase64()
+     */
+    public static function generateHashSalt($count = 32) {
+        return str_replace(['+', '/', '='], ['-', '_', ''], base64_encode(random_bytes($count)));
+    }
 }


### PR DESCRIPTION
This PR contains a few improvements that apply to D8 sites:

1) Set `DKTL_DOCKER=1` in web container
1) Add hash salt to `settings.php` during `dktl init`
1) Define config sync directory in `settings.php` (the sync directory is created automatically during the Drupal/DKAN installation).
