### PR TITLE
Allow passing extra phpunit arguments somewhat directly via the robo …

### DIFF
--- a/bin/dktl
+++ b/bin/dktl
@@ -160,7 +160,8 @@ elif [ "$DKTL_MODE" = "HOST" ]; then
     echo "${1} is not available in 'HOST' mode"
     exit 1
   fi
-  if [ "$1" = "drush" ] || [ "$1" = "test:behat" ] || [ "$1" = "test:phpunit" ] || [ "$1" = "test:lint" ] || [ "$1" = "test:lint-fix" ]; then
+
+  if [ "$1" = "drush" ] || [ "$1" = "test:behat" ] || [ "$1" = "phpunit" ] || [ "$1" = "test:phpunit" ] || [ "$1" = "dkan:test-phpunit" ] || [ "$1" = "test:lint" ] || [ "$1" = "test:lint-fix" ]; then
     # For several commands, we want to insert a "--" to pass all arguments as an array.
     php $DKTL_DIRECTORY/bin/app.php $1 -- "${@:2}"
   else

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -41,30 +41,7 @@ class BasicCommands extends \Robo\Tasks
         }
         return $exec->run();
     }
-    
-    /**
-     * Proxy to phpunit.
-     */
-    public function phpunit(array $cmd) {
-        
-        $projDir = Util::getProjectDirectory();
-        $phpunitExecutable = "{$projDir}/docroot/vendor/bin/phpunit";
-        
-        $exec = $this->taskExec($phpunitExecutable);
-        
-        // currently dktl only passes args as an array to the commands.
-        // some sanitisation is needed.
-        foreach ($cmd as $arg) {
-            if (strpos($arg, '=')) {
-                list($option, $value) = explode('=', $arg, 2);
-                $exec->option($option, $value);
-            } else {
-                $exec->option($arg);
-            }
-        }
-        
-        return $exec->run();
-    }
+
 
     /**
      * Performs common tasks when switching databases or code bases.

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -41,7 +41,30 @@ class BasicCommands extends \Robo\Tasks
         }
         return $exec->run();
     }
-
+    
+    /**
+     * Proxy to phpunit.
+     */
+    public function phpunit(array $cmd) {
+        
+        $projDir = Util::getProjectDirectory();
+        $phpunitExecutable = "{$projDir}/docroot/vendor/bin/phpunit";
+        
+        $exec = $this->taskExec($phpunitExecutable);
+        
+        // currently dktl only passes args as an array to the commands.
+        // some sanitisation is needed.
+        foreach ($cmd as $arg) {
+            if (strpos($arg, '=')) {
+                list($option, $value) = explode('=', $arg, 2);
+                $exec->option($option, $value);
+            } else {
+                $exec->option($arg);
+            }
+        }
+        
+        return $exec->run();
+    }
 
     /**
      * Performs common tasks when switching databases or code bases.

--- a/src/Drupal/V7/BasicCommands.php
+++ b/src/Drupal/V7/BasicCommands.php
@@ -43,5 +43,21 @@ class BasicCommands extends \Robo\Tasks
             $this->io()->success('Backup created in "backups" folder.');
         }
     }
+    
+    /**
+     * Proxy to the phpunit binary.
+     *
+     * @param array $args  Arguments to append to full phpunit command.
+     */
+    public function phpunit(array $args)
+    {
+        $phpunitExec = $this->taskExec('bin/phpunit');
+
+        foreach ($args as $arg) {
+            $phpunitExec->arg($arg);
+        }
+        
+        return $phpunitExec->run();
+    }
 
 }

--- a/src/Drupal/V8/BasicCommands.php
+++ b/src/Drupal/V8/BasicCommands.php
@@ -238,4 +238,25 @@ class BasicCommands extends \Robo\Tasks
     public function install() {
         $this->_exec("dktl drush si -y");
     }
+    
+    /**
+     * Proxy to the phpunit binary.
+     *
+     * @param array $args  Arguments to append to full phpunit command.
+     */
+    public function phpunit(array $args) {
+
+        $proj_dir = Util::getProjectDirectory();
+
+        $phpunit_executable = "{$proj_dir}/docroot/vendor/bin/phpunit";
+
+        $phpunitExec = $this->taskExec($phpunit_executable);
+
+        foreach ($args as $arg) {
+            $phpunitExec->arg($arg);
+        }
+
+        return $phpunitExec->run();
+    }
+
 }

--- a/src/Drupal/V8/DkanCommands.php
+++ b/src/Drupal/V8/DkanCommands.php
@@ -53,7 +53,8 @@ class DkanCommands extends \Robo\Tasks
         $this->taskExec("sed -i.bak 's/trigger_error/\/\/trigger_error/' {$file}")
             ->run();
 
-        $phpunitExec = $this->taskExec("{$phpunit_executable} --testsuite=\"DKAN Test Suite\"")
+        $phpunitExec = $this->taskExec($phpunit_executable)
+            ->option('testsuite', 'DKAN Test Suite')
             ->dir("{$proj_dir}/docroot/profiles/contrib/dkan2");
         
         // currently dktl only passes args as an array to the commands.

--- a/src/Drupal/V8/DkanCommands.php
+++ b/src/Drupal/V8/DkanCommands.php
@@ -26,7 +26,7 @@ class DkanCommands extends \Robo\Tasks
     }
 
     /**
-     * Run DKAN PhpUnit Tests. Additional pgpunit CLI options can be passed.
+     * Run DKAN PhpUnit Tests. Additional phpunit CLI options can be passed.
      * 
      * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions 
      * @param array $args  Arguments to append to phpunit command.

--- a/src/Drupal/V8/DkanCommands.php
+++ b/src/Drupal/V8/DkanCommands.php
@@ -26,19 +26,8 @@ class DkanCommands extends \Robo\Tasks
     }
 
     /**
-     * Run DKAN PhpUnit Tests.
+     * Run DKAN PhpUnit Tests. Additional pgpunit CLI options can be passed.
      * 
-     * Because of a limitation of using the single `$args` array to pass all
-     * additional arguments, the phpunit specific arguments can be only be
-     * passed without the `--` prefix to avoid conflicting with Robo\Tasks
-     * built in arguments.
-     * 
-     * e.g. dtlk dkan:test-phpunit debug verbose coverage-html=../logs/coverage
-     *
-     * Note that only full option names will work and not single letter arguments
-     * i.e. use `verbose` instead of `v`
-     * 
-     * @todo currently `--testsuite` is a hardoced argument. Could refactor if additional test suites are added
      * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions 
      * @param array $args  Arguments to append to phpunit command.
      */
@@ -57,20 +46,10 @@ class DkanCommands extends \Robo\Tasks
             ->option('testsuite', 'DKAN Test Suite')
             ->dir("{$proj_dir}/docroot/profiles/contrib/dkan2");
         
-        // currently dktl only passes args as an array to the commands.
-        // some sanitisation is needed.
         foreach ($args as $arg) {
-            
-            if(strpos($arg,'=')) {
-                list($option, $value) = explode('=', $arg, 2);
-                $phpunitExec->option($option, $value);
-            }
-            else
-            {
-                $phpunitExec->option($arg);
-            }
+            $phpunitExec->arg($arg);
         }
-        
+
         $phpunitExec->run();
         
         $this->taskExec("sed -i.bak 's/\/\/trigger_error/trigger_error/' {$file}")


### PR DESCRIPTION
…task.

Current implementation did not allow passing additional arguments to the `phpunit` command. this modification should allow us to do that. somewhat.