### PR TITLE
Database backup excluding tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ As described below, these options can be stored in a configuration file so that 
 
 You may also restore from a local database backup, as long as it is placed in a folder under the project root called _/backups_. Type `dktl db:restore` with no argument, and the backup in _/backups_ will be restored if there is only one, or you will be allowed to select from a list if there are several.
 
+## Create and grab a database dump excluding tables
+
+You can create a database dump excluding tables related to cache, devel, webform submissions and DKAN datastore. Running the command `dktl site:grab-database @alias` will create the database backup for the drush alias passed as argument.
+
+This command needs to be run with DKTL_MODE set to "HOST". So you'll need to run `export DKTL_MODE="HOST"` and after the command finishes, you should set it back to its old value or just unset the variable by running `unset DKTL_MODE`.
+
+If you want to import this dump into your local development site, then you can move the file _excluded\_tables.sql_ into the directory _backups_ in the root of your project, then you'll be able to import it by running `dktl restore:db excluded_tables.sql`.
+
 ## Configuring DKTL commands
 
 You will probably want to set up some default arguments for certain commands, especially the urls for the `restore` command. This is what the dkan.yml file is for. You can provide options for any DKTL command in dkan.yml. For instance:

--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -79,8 +79,6 @@ services:
       # Host SSH keys mapping. Uncomment one of the lines below based on your setup.
       - ~/.ssh:/root/.ssh
       - ~/.aws:/root/.aws
-      # Host drush aliases mapping.
-      - ~/.drush:/root/.drush
     labels:
       - traefik.enable=false
     network_mode: bridge

--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -79,6 +79,8 @@ services:
       # Host SSH keys mapping. Uncomment one of the lines below based on your setup.
       - ~/.ssh:/root/.ssh
       - ~/.aws:/root/.aws
+      # Host drush aliases mapping.
+      - ~/.drush:/root/.drush
     labels:
       - traefik.enable=false
     network_mode: bridge

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -128,4 +128,38 @@ class BasicCommands extends \Robo\Tasks
             throw new \Exception("Failed, xdebug.ini not found.");
         }
     }
+
+  /**
+   * Create a database dump excluding devel and datastore tables.
+   *
+   * Run drush command on $alias to create a database dump excluding tables
+   * related to devel and datastore.
+   *
+   * @param String $alias Drush alias of the site we want the db from.
+   */
+  public function siteGrabDatabase($alias)
+  {
+    // Tables for which we want the structure and not the data.
+    $structure_tables_common = array(
+      'accesslog', 'batch', 'cache', 'cache_*', '*_cache', 'ctools_views_cache',
+      'ctools_object_cache', 'flood', 'history', 'queue', 'search_*',
+      'semaphore', 'sessions', 'watchdog'
+    );
+    $structure_tables_devel = array('devel_queries', 'devel_times');
+    $structure_tables_webform = array('webform_submitted_data');
+    $skip_tables = array('dkan_datastore_*');
+    $structure_tables = array_merge(
+      $structure_tables_common,
+      $structure_tables_devel,
+      $structure_tables_webform
+    );
+    $structure_tables_list = implode(', ', $structure_tables);
+    // Tables to be completely skipped.
+    $skip_tables = array('dkan_datastore_*');
+    $skip_tables_list = implode(', ', $skip_tables);
+
+    $command = "drush $alias sql-dump --structure-tables-list='" . $structure_tables_list . "' --skip-tables-list='" . $skip_tables_list . "' > excluded_tables.sql";
+    //$command = "drush $alias sql-dump --structure-tables-list='" . $structure_tables_list . "' > excluded_tables.sql";
+    return $this->taskExec($command)->run();
+  }
 }

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -159,7 +159,6 @@ class BasicCommands extends \Robo\Tasks
     $skip_tables_list = implode(', ', $skip_tables);
 
     $command = "drush $alias sql-dump --structure-tables-list='" . $structure_tables_list . "' --skip-tables-list='" . $skip_tables_list . "' > excluded_tables.sql";
-    //$command = "drush $alias sql-dump --structure-tables-list='" . $structure_tables_list . "' > excluded_tables.sql";
     return $this->taskExec($command)->run();
   }
 }

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -147,7 +147,6 @@ class BasicCommands extends \Robo\Tasks
     );
     $structure_tables_devel = array('devel_queries', 'devel_times');
     $structure_tables_webform = array('webform_submitted_data');
-    $skip_tables = array('dkan_datastore_*');
     $structure_tables = array_merge(
       $structure_tables_common,
       $structure_tables_devel,


### PR DESCRIPTION
Connects https://github.com/getdkan/dkan/issues/2822

## Description

Added command for creating a database backup excluding cache, devel, webform submissions and DKAN datastore tables. This command works fine just when it is run on DKTL_MODE set to HOST because otherwise the drush aliases are not passed to the docker containers and even when we do that we get issues because of ssh/config owners and permissions. 

## Steps to test
- [ ] Run `export DKTL_MODE="HOST"`
- [ ] Run `dktl site:grab-database @alias` with `@alias` being a drush alias for a site which you have access to.
- [ ] Set DKTL_MODE back or unset the variable by running `unset DKTL_MODE`
- [ ] A new file `excluded_tables.sql` should be created in your current directory.
- [ ] You can import that dump in your project by moving the file to `backups` folder in the root of your project and then running `dktl restore:db excluded_tables.sql`
- [ ] Run `dktl drush sqlc` and confirm you don't have the dkan_datastore_* tables in there.