### PR TITLE
Automatically set up custom tests on project

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ DKTL should have already provided some things in _/src/site_: _settings.php_ con
 
 DKAN Tools supports custom PHPUnit and Behat tests found in the _src/test_ directory.
 
+If your site does not have tests set up yet, running `dktl init:custom-tests` will set up a _src/test_ directory in your project with sample phpunit and behat tests to start from.
+
 To run custom tests:
 
 ```bash
@@ -150,18 +152,19 @@ and
 dktl test:behat-custom
 ```
 
-To configure PHPUnit tests:
+To manually configure custom phpunit tests (without using `dktl init:custom-tests`):
 
 1. Create _src/test/phpunit_
-2. Place a _phpunit.xml_ configuration file in _src/test/phpunit_.  You can use the _phpunit.xml_ file in _dkan/test/phpunit_ as an example.
-3. Store your tests in _src/test/phpunit_.
+2. Place a _phpunit.xml_ configuration file in _src/test/phpunit_.  You can use the [_phpunit.xml_ file in _dkan/test/phpunit_](https://github.com/GetDKAN/dkan/blob/7.x-1.x/test/phpunit/phpunit.xml) as an example, replacing the `<testsuite>` elements to reflect your own custom tests. See the [PHPUnit documentation](https://phpunit.readthedocs.io/en/7.0/organizing-tests.html#composing-a-test-suite-using-xml-configuration) for more information.
+3. Add a copy of [_dkan/test/phpunit/boot.php_](https://github.com/GetDKAN/dkan/blob/7.x-1.x/test/phpunit/boot.php) in the same directory.
+3. Store your tests in _src/test/phpunit_. Again, use [_dkan/test/phpunit_](https://github.com/GetDKAN/dkan/tree/7.x-1.x/test/phpunit) as a guide.
 
 JUnit style test results will be written to _src/test/assets/junit_.
 
-To configure Behat tests:
+To manually configure Behat tests:
 
-1. Create _src/test/features_
-2. Place Behat configuration files _behat.yml_ and _behat.docker.yml_ in _src/test_.  You can use the corresponding files in _dkan/test_ as references.
+1. Create _src/test/features_ directory.
+2. Place Behat configuration files _behat.yml_ and _behat.docker.yml_ in _src/test_.  You can use the corresponding files in [_dkan/test_](https://github.com/GetDKAN/dkan/tree/7.x-1.x/test) as references, or even just create symbolic links to them.
 3. Store you tests in _src/test/features_.
 
 JUnit style test results will be written to _src/test/assets/junit_.

--- a/assets/test/behat.docker.yml
+++ b/assets/test/behat.docker.yml
@@ -1,0 +1,12 @@
+imports:
+  - behat.yml
+
+default:
+  extensions:
+    Behat\MinkExtension:
+      base_url: "http://web"
+      selenium2:
+        wd_host: "http://browser:4444/wd/hub"
+    Drupal\DrupalExtension:
+      drupal:
+        drupal_root: "%paths.base%/../../docroot"

--- a/assets/test/behat.yml
+++ b/assets/test/behat.yml
@@ -1,0 +1,208 @@
+---
+default:
+  suites:
+    custom:
+      contexts:
+      - FeatureContext
+      - Drupal\DrupalExtension\Context\MinkContext
+      - Drupal\DrupalExtension\Context\DrupalContext
+      - Drupal\DrupalExtension\Context\MessageContext
+      - Drupal\DrupalExtension\Context\MarkupContext
+      - Drupal\DrupalExtension\Context\BatchContext
+      - Drupal\DKANExtension\Context\DKANContext
+      - Drupal\DKANExtension\Context\MailContext
+      - Drupal\DKANExtension\Context\PageContext
+      - Drupal\DKANExtension\Context\GroupContext
+      - Drupal\DKANExtension\Context\HarvestSourceContext
+      - Drupal\DKANExtension\Context\WorkflowContext
+      - Drupal\DKANExtension\Context\DatasetAutoFillContext
+      - Drupal\DKANExtension\Context\LinkcheckerContext
+      - Drupal\DKANExtension\Context\DatasetContext:
+        - fields:
+            title: title
+            description: body
+            published: status
+            resource: field_resources
+            access level: field_public_access_level
+            contact name: field_contact_name
+            contact email: field_contact_email
+            attest name: field_hhs_attestation_name
+            attest date: field_hhs_attestation_date
+            verification status: field_hhs_attestation_negative
+            attest privacy: field_hhs_attestation_privacy
+            attest quality: field_hhs_attestation_quality
+            bureau code: field_odfe_bureau_code
+            license: field_license
+            doi: field_doi
+            citation: field_citation
+            publisher: og_group_ref
+        - labels:
+            title: Title
+            body: Description
+            field_tags: Tags
+            field_topics: Topics
+            field_license: License
+            field_author: Author
+            field_spatial_geographical_cover: Spatial / Geographical Coverage Location
+            field_frequency: Frequency
+            field_granularity: Granularity
+            field_data_dictionary_type: Data Dictionary Type
+            field_data_dictionary: Data Dictionary
+            field_contact_name: Contact Name
+            field_contact_email: Contact Email
+            field_public_access_level: Public Access Level
+            field_additional_info: Additional Info
+            field_resources: Resources
+            field_related_content: Related Content
+            field_landing_page: Homepage URL
+            field_conforms_to: Data Standard
+            field_language: Language
+            og_group_ref: Groups
+        - sets:
+            field_spatial: Spatial / Geographical Coverage Area
+            field_temporal_coverage: Temporal Coverage
+        - defaults:
+            field_public_access_level: public
+            field_hhs_attestation_negative: 1
+            field_license: odc-by
+      - Drupal\DKANExtension\Context\DataDashboardContext
+      - Drupal\DKANExtension\Context\PODContext
+      - Drupal\DKANExtension\Context\FastImportContext
+      - Drupal\DKANExtension\Context\SearchAPIContext:
+          search_forms:
+            default:
+              form_css: "#dkan-sitewide-dataset-search-form"
+              form_field: "edit-search"
+              form_button: "edit-submit"
+              results_css: ".view-dkan-datasets"
+              result_item_css: ".views-row"
+            harvest_source:
+              results_css: ".view-dkan-harvest-source-search"
+              result_item_css: ".views-row"
+      - Drupal\DKANExtension\Context\ResourceContext
+      - Drupal\DKANExtension\Context\ServicesContext:
+        - request_fields_map:
+            resource:
+              type: type
+              title: title
+              body: body[und][0][value]
+              status: status
+            dataset:
+              type: type
+              title: title
+              status: status
+              published: status
+              body: body[und][0][value]
+              description: body[und][0][value]
+              tags: field_tags[und][value_field]
+              resource: field_resources[und][0][target_id]
+              access level: field_public_access_level[und]
+              contact name: field_contact_name[und][0][value]
+              contact email: field_contact_email[und][0][value]
+              attest name: field_hhs_attestation_name[und][0][value]
+              attest date: field_hhs_attestation_date[und][0][value][date]
+              verification status: field_hhs_attestation_negative[und]
+              attest privacy: field_hhs_attestation_privacy[und]
+              attest quality: field_hhs_attestation_quality[und]
+              bureau code: field_odfe_bureau_code[und]
+              license: field_license[und][select]
+              doi: field_doi[und][0][value]
+              citation: field_citation[und][0][value]
+              program code: field_odfe_program_code[und][]
+              groups: og_group_ref[und][]
+              publisher: og_group_ref[und][]
+      - Drupal\DKANExtension\Context\PODContext
+      - Drupal\DKANExtension\Context\DatastoreContext
+      - Drupal\DKANExtension\Context\TimezoneContext
+      - Drupal\DrupalExtension\Context\DrushContext
+      - Devinci\DevinciExtension\Context\DebugContext:
+          asset_dump_path: "%paths.base%/assets"
+      - Devinci\DevinciExtension\Context\JavascriptContext:
+          maximum_wait: 30
+  formatters:
+    pretty:
+      output_styles:
+        comment:
+        - default
+        - default
+        - [conceal]
+  gherkin:
+    filters:
+      tags: ~@fixme
+  extensions:
+    Behat\MinkExtension:
+      goutte:
+        guzzle_parameters:
+          verify: false
+
+      selenium2: []
+
+      default_session: "goutte"
+      javascript_session: "selenium2"
+      browser_name: chrome
+      files_path: "%paths.base%/files"
+    Drupal\DrupalExtension:
+      blackbox:
+      drupal:
+        drupal_root: "%paths.base%/../../docroot"
+      api_driver: "drupal"
+      region_map:
+        admin menu: "#admin-menu"
+        breadcrumb: ".breadcrumb"
+        comment: ".comment-main"
+        content search: ".form-item-query"
+        content: ".region-content"
+        close-modal: ".ctools-close-modal"
+        dashboards: ".view-data-dashboards table tbody"
+        dataset body: ".field-name-body"
+        dataset edit body: "#edit-body"
+        dataset resource list: "#data-and-resources"
+        dataset spatial: "#edit-field-spatial"
+        dataset title: ".pane-node-content .pane-title"
+        datasets: ".view-dkan-datasets"
+        dropdown_links: ".comment-main .links.inline.dropdown-menu"
+        facet container: ".radix-layouts-sidebar"
+        filter by author: ".facetapi-facet-author"
+        filter by date changed: ".facetapi-facet-changed"
+        filter by resource format: ".facetapi-facet-field-resourcesfield-format"
+        filter by tag: ".facetapi-facet-field-tags"
+        filter by topics: ".facetapi-facet-field-topic"
+        footer: "#footer"
+        group block: ".pane-views-group-block-block"
+        group members: ".view-id-dkan_og_extras_group_members"
+        group subscribe: ".group-subscribe-message"
+        groups: ".view-content"
+        harvest datasets: ".view-dkan-harvest-datasets"
+        header: "#header"
+        left header: "#header-left"
+        left_sidebar: ".panel-col-first"
+        modal: "#modalContent"
+        navigation: ".navigation-wrapper"
+        other access: ".pane-dkan-sitewide-dkan-sitewide-other-access"
+        page header: ".page-header"
+        primary tabs: ".tabs--primary"
+        recline preview: ".recline-data-explorer"
+        resource groups: "#edit-groups"
+        resource title: ".pane-node-content .pane-title"
+        results: ".view-header"
+        right header: "#header-right"
+        right sidebar: "#column-right"
+        search content results: ".content"
+        search_area: ".panel-col-last"
+        social: ".pane-dkan-sitewide-dkan-sitewide-social"
+        tabs: ".field-group-htabs-wrapper"
+        toolbar: ".tabs--primary"
+        user block: ".pane-views-user-profile-fields-block"
+        user command center: ".pane-dkan-sitewide-profile-page-dkan-user-summary"
+        user content: ".view-user-profile-search"
+        user page: ".main"
+        user profile: ".pane-dkan-sitewide-panels-dkan-user-summary"
+      text:
+        log_out: "Log out"
+        log_in: "Log in"
+      selectors:
+        message_selector: ".alert"
+        error_message_selector: ".alert.alert-error"
+        success_message_selector: ".alert.alert-success"
+    Drupal\DKANExtension:
+      some_param: "test"

--- a/assets/test/features/bootstrap/FeatureContext.php
+++ b/assets/test/features/bootstrap/FeatureContext.php
@@ -1,0 +1,12 @@
+<?php
+
+use Drupal\DKANExtension\Context\RawDKANContext;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+
+/**
+ * Defines application features from the specific context.
+ */
+class FeatureContext extends RawDKANContext
+{
+  // This file is meant for custom step functions.
+}

--- a/assets/test/phpunit/boot.php
+++ b/assets/test/phpunit/boot.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @file
+ * Bootstraps Drupal 7 site.
+ */
+
+use Drupal\Driver\DrupalDriver;
+use Drupal\Driver\Cores\Drupal7;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// Path to Drupal.
+$dir = implode('/', array(__DIR__, '..', '..', '..', 'docroot'));
+
+// Host.
+$uri = getenv('DKAN_WEB_1_PORT_80_TCP_ADDR') ? 'http://' . getenv('DKAN_WEB_1_PORT_80_TCP_ADDR') : 'http://web';
+
+$driver = new DrupalDriver($dir, $uri);
+$driver->setCoreFromVersion();
+
+// Bootstrap Drupal.
+$driver->bootstrap();

--- a/assets/test/phpunit/example/CustomTest.php
+++ b/assets/test/phpunit/example/CustomTest.php
@@ -1,0 +1,7 @@
+<?php
+
+class CustomTest extends \PHPUnit_Framework_TestCase {
+    public function test() {
+        $this->assertTrue(1 == 1);
+    }
+}

--- a/assets/test/phpunit/phpunit.xml
+++ b/assets/test/phpunit/phpunit.xml
@@ -1,0 +1,19 @@
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         syntaxCheck="false"
+         bootstrap="boot.php"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         colors="true">
+    <testsuites>
+        <testsuite name="Custom Test Suite Example">
+            <file>example/CustomTest.php</file>
+        </testsuite>
+    </testsuites>
+
+    <php>
+        <ini name="display_errors" value="true"/>
+        <includePath>.</includePath>
+    </php>
+</phpunit>

--- a/src/Drupal/V7/InitCommands.php
+++ b/src/Drupal/V7/InitCommands.php
@@ -31,7 +31,68 @@ class InitCommands extends \Robo\Tasks
         }
     }
 
+    /**
+     * Initialize custom test directories.
+     *
+     * Running dktl init:custom-tests will create a /src/test folder in your
+     * project if one does not exist, and populate it with example custom
+     * phpunit and behat tests that should run and pass on any project. You can
+     * run these tests with the test:phpunit-custom and test:behat-custom
+     * commands.
+     * 
+     * For new sites this command will automatically be run as part of 
+     * dktl:init.
+     */
+    public function initCustomTests()
+    {
+        $dktlRoot = Util::getDktlDirectory();
+        $this->io()->section('Initializing src/test directory');
+        if (!is_dir('src/test')) {
+            $result = $this->_mkdir('src/test');
+            Util::directoryAndFileCreationCheck($result, 'src/test', $this->io);
+        }
+        if (file_exists('src/test/behat.yml')) {
+            $this->io()->note("Custom behat tests appear to already be configured.");
+        } else {
+            $files = ['behat.yml', 'behat.docker.yml'];
+            foreach ($files as $file) {
+                $f = "src/test/{$file}";
+                $result = $this->taskWriteToFile($f)
+                    ->textFromFile("{$dktlRoot}/assets/test/{$file}")
+                    ->run();
+                Util::directoryAndFileCreationCheck($result, $f, $this->io);
+            }
 
+            $result = $this->_mkdir('src/test/features');
+            Util::directoryAndFileCreationCheck($result, 'src/test/features', $this->io);
+            $result = $this->_mkdir('src/test/features/bootstrap');
+            Util::directoryAndFileCreationCheck($result, 'src/test/features/bootstrap', $this->io);
+
+            $f = "test/features/bootstrap/FeatureContext.php";
+            $result = $this->taskWriteToFile("src/{$f}")
+                ->textFromFile("{$dktlRoot}/assets/{$f}")
+                ->run();
+            Util::directoryAndFileCreationCheck($result, "src/$f", $this->io);
+        }
+        if (file_exists('src/test/phpunit/phpunit.xml')) {
+            $this->io()->note("Custom phpunit tests appear to already be configured.");
+        } else {
+            $result = $this->_mkdir('src/test/phpunit');
+            Util::directoryAndFileCreationCheck($result, 'src/test/phpunit', $this->io);
+            $result = $this->_mkdir('src/test/phpunit/example');
+            Util::directoryAndFileCreationCheck($result, 'src/test/phpunit/example', $this->io);
+
+            $files = ['phpunit.xml', 'boot.php', 'example/CustomTest.php'];
+            foreach ($files as $file) {
+                $f = "src/test/phpunit/{$file}";
+                $result = $this->taskWriteToFile($f)
+                    ->textFromFile("{$dktlRoot}/assets/test/phpunit/{$file}")
+                    ->run();
+                Util::directoryAndFileCreationCheck($result, $f, $this->io);
+            }
+        }
+    }
+    
     private function createDktlYmlFile()
     {
         $dktlRoot = Util::getDktlDirectory();
@@ -61,6 +122,7 @@ class InitCommands extends \Robo\Tasks
         $this->createSiteFilesDirectory();
         $this->createSettingsFiles($host);
         $this->setupScripts();
+        $this->initCustomTests();
     }
 
     private function setupScripts() {
@@ -161,5 +223,4 @@ class InitCommands extends \Robo\Tasks
 
         return $result;
     }
-
 }

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -78,8 +78,7 @@ class Util
         if ($result->getExitCode() == 0 && file_exists($df)) {
             $io->success("{$df} was created.");
         } else {
-            $io->error("{$df} was not created.");
-            exit;
+            throw new \Exception("{$df} was not created.");
         }
     }
 

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -78,7 +78,8 @@ class Util
         if ($result->getExitCode() == 0 && file_exists($df)) {
             $io->success("{$df} was created.");
         } else {
-            throw new \Exception("{$df} was not created.");
+            $io->error("{$df} was not created.");
+            exit;
         }
     }
 


### PR DESCRIPTION
To make sure we have an easy way to set up custom tests, this adds a `dktl init:custom-tests` command to dkan-tools, which sets up the scaffolding of a custom test suite. It is also now included in a standard `dktl init` command.

## QA Steps

1. Start a new dktl project, build and install DKAN
2. Try the `dktl test:behat-custom` and `dktl test:phpunit-custom` commands.