### PR TITLE
Use exception instead of just io() error on file check

### DIFF
--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -78,8 +78,7 @@ class Util
         if ($result->getExitCode() == 0 && file_exists($df)) {
             $io->success("{$df} was created.");
         } else {
-            $io->error("{$df} was not created.");
-            exit;
+            throw new \Exception("{$df} was not created.");
         }
     }
 


### PR DESCRIPTION
It seems like we might want to actually throw an exception rather than just some output when the init commands fail to create files. But I may be forgetting why we wrote that Util method that way in the first place. Thoughts @fmizzell ?