### PR TITLE
Add Dredd tests

### DIFF
--- a/src/Drupal/V8/DkanCommands.php
+++ b/src/Drupal/V8/DkanCommands.php
@@ -27,6 +27,21 @@ class DkanCommands extends \Robo\Tasks
     }
 
     /**
+     * Run DKAN Dredd Tests.
+     */
+    public function dkanTestDredd()
+    {
+        $proj_dir = Util::getProjectDirectory();
+        $this->taskExec("npm install dredd")
+            ->dir("{$proj_dir}/docroot/profiles/contrib/dkan2")
+            ->run();
+
+        return $this->taskExec("npx dredd --hookfiles=./dredd-hooks.js")
+            ->dir("{$proj_dir}/docroot/profiles/contrib/dkan2/dredd")
+            ->run();
+    }
+
+    /**
      * Run DKAN PhpUnit Tests. Additional phpunit CLI options can be passed.
      *
      * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions


### PR DESCRIPTION
This adds a `dkan:test-dredd` command to `dktl`.

### Steps to test:
1. Check out this branch in your local `dkan-tools` repo
1. From within your dkan site, run `dktl dkan:test-dreed`
1. Verify that Dredd was installed and then ran