### PR TITLE
Quote find command in chown

### DIFF
--- a/bin/dktl
+++ b/bin/dktl
@@ -142,7 +142,7 @@ if [ "$DKTL_MODE" = "DOCKER" ]; then
 
   if [ -z $DKTL_CHOWN ] || [ "$DKTL_CHOWN" = "TRUE" ]; then
     # Docker creates files that appear as owned by root on host. Fix:
-    if [ ! -z `find $DKTL_PROJECT_DIRECTORY -user root -print -quit` ]; then
+    if [ ! -z "`find $DKTL_PROJECT_DIRECTORY -user root -print -quit`" ]; then
         $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli chown -R `id -u`:`id -g` /var/www
     fi
   fi


### PR DESCRIPTION
All `dktl` commands for me on a certain project were ending output with:

```
/home/██████/local/bin/dktl: line 145: [: too many arguments
```

I realized it was because the find command on that line was returning filenames with spaces in them, which were not being escaped in any way. Wrapping the whole expression in quotes prevents this. 

## How to reproduce

1. With current dkan-tools master, run `dktl dc exec cli bash`
2. Go to the project root (/var/www) 
3. Create two files with a space in the file name: `touch 'file 1' && touch 'file 1'`
4. `exit`
5. Run `dktl` and see the "too many arguments" error

## QA Steps

1. Check out this branch
2. Go to the project root (/var/www) 
3. Create two files with a space in the file name: `touch 'file 1' && touch 'file 1'`
4. `exit`
5. Run `dktl` and confirm no "too many arguments" error