### PR TITLE
Added new command to patch dkan.

### DIFF
--- a/src/Drupal/V7/MakeCommands.php
+++ b/src/Drupal/V7/MakeCommands.php
@@ -31,6 +31,7 @@ class MakeCommands extends \Robo\Tasks
         $status = $this->makeProfile($make_opts);
         if ($status) {
             $status = $this->makeDrupal($opts);
+            $status = $this->dkanPatch();
         }
         return $status;
     }
@@ -118,6 +119,32 @@ class MakeCommands extends \Robo\Tasks
         }
 
     }
+
+    /**
+     * Apply patches to dkan.
+     */
+    public function dkanPatch()
+    {
+        $patchDir = Util::getProjectDirectory() . '/src/patches/dkan';
+        $patchFiles = [];
+
+        if (is_dir($patchDir)) {
+            $patchFiles += scandir($patchDir);
+        }
+        foreach ($patchFiles as $fileName) {
+            $info = pathinfo($fileName);
+            if (in_array($info['extension'], ['patch', 'diff'])) {
+                $fileRelPath = '../src/patches/dkan/' . $fileName;
+                $this->say($fileRelPath);
+                $result = $this->taskExec('patch -p1 --no-backup-if-mismatch -r - <')
+                    ->arg($fileRelPath)
+                    ->dir('dkan')
+                    ->run();
+                $this->say($result->getMessage());
+            }
+        }
+    }
+
     /**
      * Link the DKAN folder to docroot/profiles.
      */


### PR DESCRIPTION
## Test steps
- [x] Run `dktl`, the command `dktl dkan:patch` should be available.
- [x] If you have patches to dkan inside of `src/patches/dkan` they get applied when you run `dktl dkan:patch`
- [x] If you run `dktl make`, patches to dkan are applied too.