### PR TITLE
Adding the host's config related to composer to the containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,15 @@ To go back to running in docker mode, set the variable to `DOCKER` (or just dele
 
 When using the standard docker-compose environment, [Xdebug](https://xdebug.org/) can be enabled on both the web and CLI containers as needed. Running it creates a significant performance hit, so it is disabled by default. To enable, simply run `dktl xdebug:start`. A new file will be added to _/src/docker/etc/php_, and the corresponding containers will restart. In most situations, this file should be excluded from version control with .gitignore.
 
+### Configuration Brought into the Containers from the Host Machine.
+
+Unless you are running in "HOST" mode, DKTL runs inside of docker containers. Some configuration from your host machine can be useful inside of the containers: ssh configuration, external services authentication tokens, etc.
+
+DKTL recognized this and by default makes some configurations available to the containers by default. If any of these directories exist in your current user's profile, they will be available in the container:
+* .ssh
+* .aws
+* .composer
+
 ## A note to users of DKAN Starter
 
 Users of [DKAN Starter](https://github.com/GetDKAN/dkan_starter) will recognize some concepts here. The release of DKAN Tools eliminates the need for a separate DKAN Starter project, as it provides a workflow to build sites directly from DKAN releases. Support for DKAN Starter and its accompanying [Ahoy](http://www.ahoycli.com/en/latest/) commands is ending, and detailed instructions for migrating DKAN Starter projects to the DKAN Tools workflow is coming soon.

--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -77,6 +77,7 @@ services:
       # Host SSH keys mapping. Uncomment one of the lines below based on your setup.
       - ~/.ssh:/root/.ssh
       - ~/.aws:/root/.aws
+      - ~/.composer:/root/.composer
     labels:
       - traefik.enable=false
     network_mode: bridge


### PR DESCRIPTION
Github throws a fit through composer some times. 
When that happens it asks you to create a token. 
That token is placed in a directory in the user's profile. 
This PR shares that directory from the host machine into the CLI container, so the token is set once and available every time the container runs composer.