### PR TITLE
Create configuration profile-like module for fresh d8 install

### DIFF
--- a/assets/d8/composer.json
+++ b/assets/d8/composer.json
@@ -1,11 +1,7 @@
 {
-    "description": "Project",
+    "description": "Data Catalog Project",
     "minimum-stability": "dev",
     "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/fmizzell/json_form"
-        },
         {
             "type": "composer",
             "url": "https://asset-packagist.org"

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -236,7 +236,19 @@ class BasicCommands extends \Robo\Tasks
 
     public function install($opts = ['frontend' => false])
     {
-        $result = $this->taskExec('drush si -y')
+        $result = $this->taskExec('drush si standard -y')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+        $result = $this->taskExec('drush en dkan2 dkan_admin dkan_harvest dkan_dummy_content dblog config_update_ui -y')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+        $result = $this->taskExec('drush config-set system.performance css.preprocess 0 -y')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+        $result = $this->taskExec('drush config-set system.performance js.preprocess 0 -y')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+        $result = $this->taskExec('drush config-set system.site page.front "//dkan/home" -y')
             ->dir(Util::getProjectDocroot())
             ->run();
 

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -30,11 +30,11 @@ class DkanCommands extends \Robo\Tasks
         }
 
         $this->taskExec("npm install cypress")
-        ->dir("{$proj_dir}/docroot/profiles/contrib/dkan2")
+        ->dir("{$proj_dir}/docroot/modules/contrib/dkan2")
         ->run();
 
         return $this->taskExec("CYPRESS_baseUrl=http://web npx cypress run")
-            ->dir("{$proj_dir}/docroot/profiles/contrib/dkan2")
+            ->dir("{$proj_dir}/docroot/modules/contrib/dkan2")
             ->run();
     }
 
@@ -45,11 +45,11 @@ class DkanCommands extends \Robo\Tasks
     {
         $proj_dir = Util::getProjectDirectory();
         $this->taskExec("npm install dredd")
-            ->dir("{$proj_dir}/docroot/profiles/contrib/dkan2")
+            ->dir("{$proj_dir}/docroot/modules/contrib/dkan2")
             ->run();
 
         return $this->taskExec("npx dredd --hookfiles=./dredd-hooks.js")
-            ->dir("{$proj_dir}/docroot/profiles/contrib/dkan2/dredd")
+            ->dir("{$proj_dir}/docroot/modules/contrib/dkan2/dredd")
             ->run();
     }
 
@@ -70,7 +70,7 @@ class DkanCommands extends \Robo\Tasks
 
         $phpunitExec = $this->taskExec($phpunit_executable)
             ->option('testsuite', 'DKAN Test Suite')
-            ->dir("{$proj_dir}/docroot/profiles/contrib/dkan2");
+            ->dir("{$proj_dir}/docroot/modules/contrib/dkan2");
 
         foreach ($args as $arg) {
             $phpunitExec->arg($arg);
@@ -89,7 +89,7 @@ class DkanCommands extends \Robo\Tasks
         putenv("CC_TEST_REPORTER_ID={$code_climate_reporter_id}");
 
         $proj_dir = Util::getProjectDirectory();
-        $dkan_dir = "{$proj_dir}/docroot/profiles/contrib/dkan2";
+        $dkan_dir = "{$proj_dir}/docroot/modules/contrib/dkan2";
 
         if (!file_exists("{$dkan_dir}/cc-test-reporter")) {
             $this->taskExec(

--- a/tests/DktlTest.php
+++ b/tests/DktlTest.php
@@ -99,7 +99,7 @@ class DktlTest extends \PHPUnit\Framework\TestCase
         exec("ls sandbox/docroot", $output);
         $this->assertContains("core", $output);
         $this->assertContains("modules", $output);
-        $this->assertContains("profiles", $output);
+        $this->assertContains("modules", $output);
         $this->assertContains("sites", $output);
         $this->assertContains("themes", $output);
     }
@@ -108,7 +108,7 @@ class DktlTest extends \PHPUnit\Framework\TestCase
     {
         `cd sandbox && dktl make`;
         $output = [];
-        exec("ls sandbox/docroot/profiles/contrib", $output);
+        exec("ls sandbox/docroot/modules/contrib", $output);
         $this->assertContains("dkan2", $output);
     }
 


### PR DESCRIPTION
Temporary "pseudo profile" drush steps added to enable modules and adjust config so there are not burdensome manual steps for standing up an OOB site.

connected to https://github.com/GetDKAN/dkan2/compare/359-deprofiling