### PR TITLE
Remove database_data volume and add composer

### DIFF
--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -77,7 +77,7 @@ services:
       # Host SSH keys mapping. Uncomment one of the lines below based on your setup.
       - ~/.ssh:/root/.ssh
       - ~/.aws:/root/.aws
-      - ~/.composer:/root/.composer
+      - composer:/root/.composer
     labels:
       - traefik.enable=false
     network_mode: bridge
@@ -138,4 +138,4 @@ services:
       - "traefik.frontend.rule=Host:${DKTL_SLUG}-solr.${DKTL_PROXY_DOMAIN}"
     network_mode: bridge
 volumes:
-  database_data:
+  composer:


### PR DESCRIPTION
Stop using a host volume for composer to avoid collisions with host environment

## QA Steps

1. Check out this branch in your local dkan-tools
2. Create a dkan2 project
3. Some times during make, composer will ask you to create a github token to overcome rate limiting.
4. Create new dkan projects

Composer should not ask for tokens again, as they should persist.