### PR TITLE
Allow installation from existing config

### DIFF
--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -234,31 +234,36 @@ class BasicCommands extends \Robo\Tasks
         return $result;
     }
 
+    public function installStandard()
+    {
+        $result = $this->taskExec('drush si standard -y')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+        $result = $this->taskExec('drush en dkan2 dkan_admin dkan_harvest dkan_dummy_content dblog config_update_ui -y')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+        $result = $this->taskExec('drush config-set system.performance css.preprocess 0 -y')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+        $result = $this->taskExec('drush config-set system.performance js.preprocess 0 -y')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+        $result = $this->taskExec('drush config-set system.site page.front "//dkan/home" -y')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+    }
+
     public function install($opts = ['frontend' => false, 'existing-config' => false])
     {
-        if (!$opts['existing-config']) {
-            $result = $this->taskExec('drush si standard -y')
-                ->dir(Util::getProjectDocroot())
-                ->run();
-            $result = $this->taskExec('drush en dkan2 dkan_admin dkan_harvest dkan_dummy_content dblog config_update_ui -y')
-                ->dir(Util::getProjectDocroot())
-                ->run();
-            $result = $this->taskExec('drush config-set system.performance css.preprocess 0 -y')
-                ->dir(Util::getProjectDocroot())
-                ->run();
-            $result = $this->taskExec('drush config-set system.performance js.preprocess 0 -y')
-                ->dir(Util::getProjectDocroot())
-                ->run();
-            $result = $this->taskExec('drush config-set system.site page.front "//dkan/home" -y')
-                ->dir(Util::getProjectDocroot())
-                ->run();
-        } else {
+        if ($opts['existing-config']) {
             $result = $this->taskExec('drush si -y --existing-config')
                 ->dir(Util::getProjectDocroot())
                 ->run();
+        } else {
+            $this->installStandard();
         }
 
-        if ($opts['frontend'] === true) {
+        if ($opts['frontend']) {
             $result = $this->taskExec('drush en -y')
                 ->arg('dkan_frontend')
                 ->dir(Util::getProjectDocroot())
@@ -266,6 +271,8 @@ class BasicCommands extends \Robo\Tasks
         }
         return $result;
     }
+
+
 
     /**
      * Proxy to the phpunit binary.

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -234,23 +234,29 @@ class BasicCommands extends \Robo\Tasks
         return $result;
     }
 
-    public function install($opts = ['frontend' => false])
+    public function install($opts = ['frontend' => false, 'existing-config' => false])
     {
-        $result = $this->taskExec('drush si standard -y')
-            ->dir(Util::getProjectDocroot())
-            ->run();
-        $result = $this->taskExec('drush en dkan2 dkan_admin dkan_harvest dkan_dummy_content dblog config_update_ui -y')
-            ->dir(Util::getProjectDocroot())
-            ->run();
-        $result = $this->taskExec('drush config-set system.performance css.preprocess 0 -y')
-            ->dir(Util::getProjectDocroot())
-            ->run();
-        $result = $this->taskExec('drush config-set system.performance js.preprocess 0 -y')
-            ->dir(Util::getProjectDocroot())
-            ->run();
-        $result = $this->taskExec('drush config-set system.site page.front "//dkan/home" -y')
-            ->dir(Util::getProjectDocroot())
-            ->run();
+        if (!$opts['existing-config']) {
+            $result = $this->taskExec('drush si standard -y')
+                ->dir(Util::getProjectDocroot())
+                ->run();
+            $result = $this->taskExec('drush en dkan2 dkan_admin dkan_harvest dkan_dummy_content dblog config_update_ui -y')
+                ->dir(Util::getProjectDocroot())
+                ->run();
+            $result = $this->taskExec('drush config-set system.performance css.preprocess 0 -y')
+                ->dir(Util::getProjectDocroot())
+                ->run();
+            $result = $this->taskExec('drush config-set system.performance js.preprocess 0 -y')
+                ->dir(Util::getProjectDocroot())
+                ->run();
+            $result = $this->taskExec('drush config-set system.site page.front "//dkan/home" -y')
+                ->dir(Util::getProjectDocroot())
+                ->run();
+        } else {
+            $result = $this->taskExec('drush si -y --existing-config')
+                ->dir(Util::getProjectDocroot())
+                ->run();
+        }
 
         if ($opts['frontend'] === true) {
             $result = $this->taskExec('drush en -y')

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -234,7 +234,7 @@ class BasicCommands extends \Robo\Tasks
         return $result;
     }
 
-    public function installStandard()
+    private function standardInstallation()
     {
         $result = $this->taskExec('drush si standard -y')
             ->dir(Util::getProjectDocroot())
@@ -260,7 +260,7 @@ class BasicCommands extends \Robo\Tasks
                 ->dir(Util::getProjectDocroot())
                 ->run();
         } else {
-            $this->installStandard();
+            $this->standardInstallation();
         }
 
         if ($opts['frontend']) {


### PR DESCRIPTION
Use-cases:

1. Installing from an existing config, might as well bypass the installation and default modules
2. Users may not be using the Standard installation profile