### PR TITLE
Support flag --frontend-build on make command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ dktl make
 
   - Make options:
       * `--prefer-source` If you are working directly on the DKAN project or one of its libraries and want to be able to commit changes and submit pull requests. This option will be passed directly to Composer; see the [Composer CLI documentation](https://getcomposer.org/doc/03-cli.md#command-line-interface-commands) for more details.
-      * `--frontend` To **download** the React frontend application to _src/frontend_ and symlink the files to _docroot/data-catalog-frontend_.
-      * `--frontend-branch=<branch>` Works like the `--frontend` flag but instead of using master branch, it uses the specified branch from data-catalog-frontend.
+      * `--frontend` To **download** the React frontend application to _src/frontend_ and symlink the files to _docroot/data-catalog-frontend_. The master branch will be downloaded unless you specify a branch from data-catalog-frontend like this `--frontend=<branch-name>`.
       * `--tag=<tag>` To build a site using a specific DKAN tag rather than from master.
       * `--branch=<branch-name>` Similarly, you can build a specific branch of DKAN by using this option.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ dktl make
   - Make options:
       * `--prefer-source` If you are working directly on the DKAN project or one of its libraries and want to be able to commit changes and submit pull requests. This option will be passed directly to Composer; see the [Composer CLI documentation](https://getcomposer.org/doc/03-cli.md#command-line-interface-commands) for more details.
       * `--frontend` To **download** the React frontend application to _src/frontend_ and symlink the files to _docroot/data-catalog-frontend_.
+      * `--frontend-branch=<branch>` Works like the `--frontend` flag but instead of using master branch, it uses the specified branch from data-catalog-frontend.
       * `--tag=<tag>` To build a site using a specific DKAN tag rather than from master.
       * `--branch=<branch-name>` Similarly, you can build a specific branch of DKAN by using this option.
 

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -35,6 +35,8 @@ class BasicCommands extends \Robo\Tasks
      *   Convert PSR-0/4 autoloading to classmap to get a faster autoloader.
      * @option frontend
      *   Build with the DKAN frontend application.
+     * @option frontend-branch
+     *   Specify data-catalog-frontend branch to build.
      * @option tag
      *   Specify DKAN tagged release to build.
      * @option branch
@@ -47,6 +49,7 @@ class BasicCommands extends \Robo\Tasks
         'no-dev' => false,
         'optimize-autoloader' => false,
         'frontend' => false,
+        'frontend-branch' => 'master',
         'tag' => null,
         'branch' => null,
         ])
@@ -70,8 +73,9 @@ class BasicCommands extends \Robo\Tasks
         // Symlink dirs from src into docroot.
         $this->makeAddSymlinksToDrupalRoot();
 
-        if ($opts['frontend'] === true) {
-            $this->installFrontend();
+        if ($opts['frontend'] === true || $opts['frontend-branch'] !== 'master') {
+            $frontend_opts['branch'] = $opts['frontend-branch'];
+            $this->installFrontend($frontend_opts);
         }
 
         $this->io()->success("dktl make completed.");
@@ -134,11 +138,11 @@ class BasicCommands extends \Robo\Tasks
         }
     }
 
-    private function installFrontend()
+    private function installFrontend($options)
     {
         $this->io()->section('Adding frontend application');
 
-        $result = $this->downloadFrontend();
+        $result = $this->downloadFrontend($options);
 
         if ($result && $result->getExitCode() === 0) {
             $this->io()->note(
@@ -221,11 +225,11 @@ class BasicCommands extends \Robo\Tasks
         return $result;
     }
 
-    private function downloadFrontend()
+    private function downloadFrontend($options)
     {
         $result = $this->taskExec('git clone')
             ->option('depth', '1')
-            ->option('branch', 'master')
+            ->option('branch', $options['branch'])
             ->arg('https://github.com/GetDKAN/data-catalog-frontend.git')
             ->arg('frontend')
             ->dir('src')

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -34,9 +34,8 @@ class BasicCommands extends \Robo\Tasks
      * @option optimize-autoloader
      *   Convert PSR-0/4 autoloading to classmap to get a faster autoloader.
      * @option frontend
-     *   Build with the DKAN frontend application.
-     * @option frontend-branch
-     *   Specify data-catalog-frontend branch to build.
+     *   - Build with the DKAN frontend application.
+     *   - You may specify which data-catalog-frontend branch to build, defaults to master.
      * @option tag
      *   Specify DKAN tagged release to build.
      * @option branch
@@ -48,8 +47,7 @@ class BasicCommands extends \Robo\Tasks
         'prefer-dist' => false,
         'no-dev' => false,
         'optimize-autoloader' => false,
-        'frontend' => false,
-        'frontend-branch' => 'master',
+        'frontend' => 'master',
         'tag' => null,
         'branch' => null,
         ])
@@ -57,7 +55,7 @@ class BasicCommands extends \Robo\Tasks
         $this->io()->section("Running dktl make");
 
         // Add project dependencies.
-        // $this->addDrush();
+        $this->addDrush();
         $this->addDkan($opts);
 
         // Run composer install while passing the options.
@@ -73,9 +71,11 @@ class BasicCommands extends \Robo\Tasks
         // Symlink dirs from src into docroot.
         $this->makeAddSymlinksToDrupalRoot();
 
-        if ($opts['frontend'] === true || $opts['frontend-branch'] !== 'master') {
-            $frontend_opts['branch'] = $opts['frontend-branch'];
-            $this->installFrontend($frontend_opts);
+        if ($opts['frontend']) {
+            $branch = ($opts['frontend'] == 1) ? 'master' : $opts['frontend'];
+            $result = $this->taskExec('dktl frontend:get')
+                ->arg($branch)
+                ->run();
         }
 
         $this->io()->success("dktl make completed.");
@@ -138,32 +138,6 @@ class BasicCommands extends \Robo\Tasks
         }
     }
 
-    private function installFrontend($options)
-    {
-        $this->io()->section('Adding frontend application');
-
-        $result = $this->downloadFrontend($options);
-
-        if ($result && $result->getExitCode() === 0) {
-            $this->io()->note(
-                'Successfully downloaded data-catalog-frontend to /src/frontend'
-            );
-        }
-
-        if (file_exists('src/frontend')) {
-            `dktl frontend:install`;
-            $this->docrootSymlink('src/frontend', self::DRUPAL_FOLDER_NAME . '/data-catalog-frontend');
-        }
-
-        $this->io()->note(
-            'You are building DKAN with the React frontend application. ' .
-            'In order for the frontend to find the correct routes to work correctly,' .
-            'you will need to enable the dkan_frontend module. ' .
-            'Do this by running "dktl install" with the "--frontend" option as well, ' .
-            'or else run "drush en dkan_frontend" after installation.'
-        );
-    }
-
     public function installphpunit()
     {
         $result = $this->taskExec("which phpunit")->run();
@@ -222,29 +196,6 @@ class BasicCommands extends \Robo\Tasks
         } else {
             $this->io()->success("Symlinked $target to $link");
         }
-        return $result;
-    }
-
-    private function downloadFrontend($options)
-    {
-        $result = $this->taskExec('git clone')
-            ->option('depth', '1')
-            ->option('branch', $options['branch'])
-            ->arg('https://github.com/GetDKAN/data-catalog-frontend.git')
-            ->arg('frontend')
-            ->dir('src')
-            ->run();
-        if ($result->getExitCode() != 0) {
-            $this->io()->error('Could not download front-end app.');
-            return $result;
-        }
-        $result = $this->_deleteDir('src/frontend/.git');
-        if ($result->getExitCode() != 0) {
-            $this->io()->error('Could not remove front-end git folder.');
-            return $result;
-        }
-
-        $this->io()->success('frontend application added.');
         return $result;
     }
 

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -47,7 +47,7 @@ class BasicCommands extends \Robo\Tasks
         'prefer-dist' => false,
         'no-dev' => false,
         'optimize-autoloader' => false,
-        'frontend' => 'master',
+        'frontend' => null,
         'tag' => null,
         'branch' => null,
         ])

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -8,9 +8,67 @@ use Robo\Tasks;
 class FrontendCommands extends Tasks
 {
   /**
-   * Install frontend app.
+   * Get frontend app.
+   */
+    public function frontendGet($branch = 'master')
+    {
+        $this->io()->section('Adding frontend application');
+
+        $result = $this->taskExec('git clone')
+            ->option('depth', '1')
+            ->option('-b', $branch)
+            ->arg('https://github.com/GetDKAN/data-catalog-frontend.git')
+            ->arg('frontend')
+            ->dir('src')
+            ->run();
+        if ($result->getExitCode() != 0) {
+            $this->io()->error('Could not download front-end app.');
+            if (file_exists('src/frontend')) {
+                $this->io()->warning('src/frontend already exists.');
+            }
+            return $result;
+        }
+
+        if ($result && $result->getExitCode() === 0) {
+            $this->io()->note(
+                'Successfully downloaded data-catalog-frontend to /src/frontend'
+            );
+        }
+
+        $this->frontendLink();
+    }
+
+    /**
+     * Create symlink for src/frontend.
+     */
+    public function frontendLink()
+    {
+        $result = $this->taskExec('ln -s ../src/frontend data-catalog-frontend')
+          ->dir("docroot")
+          ->run();
+        if ($result && $result->getExitCode() === 0) {
+            $this->io()->success(
+                'Successfully symlinked /src/frontend to docroot/data-catalog-frontend'
+            );
+        }
+
+        $this->io()->note(
+            'In order for the frontend to find the correct routes to work correctly,' .
+            'you will need to enable the dkan_frontend module. ' .
+            'Do this by running "dktl install" with the "--frontend" or "--demo" option as well, ' .
+            'or else run "drush en dkan_frontend" after installation.'
+        );
+
+        $this->io()->note(
+            'To save your customizations and make the frontend code part of your project, ' .
+            'remove the "src/frontend/.git" file.'
+        );
+    }
+
+  /**
+   * Make frontend app.
    *
-   * @todo Should this be called 'make' instead of 'install'. Generally we are using make to mean 'get dependencies'.
+   * Get frontend dependencies.
    */
     public function frontendInstall()
     {
@@ -20,18 +78,20 @@ class FrontendCommands extends Tasks
             $this->io()->error('Could not install front-end node modules');
             return $result;
         }
-        $this->io()->success('front-end installed.');
+        $this->io()->success('Front-end dependencies installed.');
     }
 
   /**
    * Build frontend app.
+   *
+   * Dataset content must exist before the dataset pages can be built.
    */
     public function frontendBuild()
     {
         $task = $this->taskExec("npm run build")->dir("src/frontend");
         $result = $task->run();
         if ($result->getExitCode() != 0) {
-            $this->io()->error('could not build the front-end.');
+            $this->io()->error('Could not build the front-end.');
             return $result;
         }
         $this->io()->success('front-end build.');

--- a/src/Command/InstallCommands.php
+++ b/src/Command/InstallCommands.php
@@ -48,6 +48,7 @@ class InstallCommands extends Tasks
         `dktl drush queue:run dkan_datastore_import`;
         `dktl drush dkan-search:rebuild-tracker`;
         `dktl drush sapi-i`;
+        `dktl frontend:get`;
         `dktl frontend:install`;
         `dktl frontend:build`;
         return  $this->taskExec('drush cr')


### PR DESCRIPTION
This allows users to build DKAN with the frontend using a specific branch of data-catalog-frontend.

## Steps to test
- [x] Running `dktl make` works as usual.
- [x] Running `dktl make --frontend` works as usual using frontend master.
- [x] Running `dktl make --frontend=[some-branch]` builds the frontend using the specified branch.