### PR TITLE
Support flag --demo-backend on install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ dktl install
       * `--frontend` Add this option again to **enable** the dkan_frontend module. This module provides the routes that connect Drupal to the decoupled front end. Be sure to follow the [frontend](https://github.com/GetDKAN/data-catalog-frontend#using-the-app) instructions for building the React application and updating pages after adding your own content.
       * `--existing-config` Add this option to preserve existing configuration.
       * `--demo` Use this option to have the frontend enabled, example content created, and the React pages built.
+      * `--demo-backend` Use this option to have the example content created, imported to the datastore and indexed without the React frontend.
 
 
 6. Access the site: `dktl drush uli --uri=dkan`, or you can find the local site URL by typing `dktl url`.

--- a/src/Command/InstallCommands.php
+++ b/src/Command/InstallCommands.php
@@ -7,7 +7,12 @@ use Robo\Tasks;
 
 class InstallCommands extends Tasks
 {
-    public function install($opts = ['frontend' => false, 'existing-config' => false, 'demo-backend' => false, 'demo' => false])
+    public function install($opts = [
+        'frontend' => false,
+        'existing-config' => false,
+        'demo-backend' => false,
+        'demo' => false
+        ])
     {
         if ($opts['existing-config']) {
             $result = $this->taskExec('drush si -y --existing-config')

--- a/src/Command/InstallCommands.php
+++ b/src/Command/InstallCommands.php
@@ -7,7 +7,7 @@ use Robo\Tasks;
 
 class InstallCommands extends Tasks
 {
-    public function install($opts = ['frontend' => false, 'existing-config' => false, 'demo' => false])
+    public function install($opts = ['frontend' => false, 'existing-config' => false, 'demo-backend' => false, 'demo' => false])
     {
         if ($opts['existing-config']) {
             $result = $this->taskExec('drush si -y --existing-config')
@@ -17,6 +17,9 @@ class InstallCommands extends Tasks
             $result = $this->standardInstallation();
         }
 
+        if ($opts['demo-backend'] === true) {
+            $result = $this->buildBackend();
+        }
         if ($opts['demo'] === true) {
             $opts = ['frontend' => false];
             $result = $this->setupDemo();
@@ -41,13 +44,21 @@ class InstallCommands extends Tasks
             ->run();
     }
 
-    private function setupDemo()
+    private function buildBackend()
     {
-        `dktl drush en dkan_dummy_content dkan_frontend -y`;
+        `dktl drush en dkan_dummy_content -y`;
         `dktl drush dkan-dummy-content:create`;
         `dktl drush queue:run dkan_datastore_import`;
         `dktl drush dkan-search:rebuild-tracker`;
-        `dktl drush sapi-i`;
+        return  $this->taskExec(`drush sapi-i`)
+            ->dir(Util::getProjectDocroot())
+            ->run();
+    }
+
+    private function setupDemo()
+    {
+        $this->buildBackend();
+        `dktl drush en dkan_frontend -y`;
         `dktl frontend:get`;
         `dktl frontend:install`;
         `dktl frontend:build`;


### PR DESCRIPTION
## Steps to test:
- [ ] Run `dktl install --demo-backend`: it should do what `dktl install` usually does but also create the dummy content, import it to the datastore and index it in search api.
- [ ] `dktl install --demo` should keep working as usual: on top of what --demo-backend does, it installs and builds the frontend.