### PR TITLE
Reset permissions when re-using containers

### DIFF
--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -35,9 +35,6 @@ class InitCommands extends \Robo\Tasks
     {
         $this->io()->section('Initializing src directory');
         if (file_exists('src')) {
-            if ($directory == "src/site") {
-                $this->_exec("chmod -R 777 {$directory}");
-            }
             $this->io()->warning('The src directory already exists in this directory; skipping.');
         } else {
             $this->createSrcDirectory($opts['host']);

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -36,7 +36,7 @@ class InitCommands extends \Robo\Tasks
         $this->io()->section('Initializing src directory');
         if (file_exists('src')) {
             if ($directory == "src/site") {
-              $this->_exec("chmod -R 777 {$directory}");
+                $this->_exec("chmod -R 777 {$directory}");
             }
             $this->io()->warning('The src directory already exists in this directory; skipping.');
         } else {

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -35,6 +35,9 @@ class InitCommands extends \Robo\Tasks
     {
         $this->io()->section('Initializing src directory');
         if (file_exists('src')) {
+            if ($directory == "src/site") {
+              $this->_exec("chmod -R 777 {$directory}");
+            }
             $this->io()->warning('The src directory already exists in this directory; skipping.');
         } else {
             $this->createSrcDirectory($opts['host']);

--- a/src/Command/InstallCommands.php
+++ b/src/Command/InstallCommands.php
@@ -27,6 +27,11 @@ class InstallCommands extends Tasks
                 ->dir(Util::getProjectDocroot())
                 ->run();
         }
+        // Workaround for https://www.drupal.org/project/drupal/issues/3091285.
+        $result = $this->taskExec('chmod u+w sites/default')
+            ->dir(Util::getProjectDocroot())
+            ->run();
+
         return $result;
     }
 


### PR DESCRIPTION
see #201 

## QA Steps
- stand up a dkan2 site so that you have a `/src` directory
- run `dktl make` again, confirm you do not get the `Could not delete /var/www/docroot/sites/default/default.services.yml:` error

![make-error](https://user-images.githubusercontent.com/314172/80984789-f4b08580-8df3-11ea-833a-686591a829c4.png)
