### PR TITLE
fix PHP Warning for undefined constant DKTL_DOCKER_PHP_ERROR

### DIFF
--- a/src/Command/DockerCommands.php
+++ b/src/Command/DockerCommands.php
@@ -30,7 +30,7 @@ class DockerCommands extends \Robo\Tasks
      */
     public function dockerCompose()
     {
-        throw new \Exception(DKTL_DOCKER_PHP_ERROR);
+        throw new \Exception(self::DKTL_DOCKER_PHP_ERROR);
     }
 
     /**
@@ -38,7 +38,7 @@ class DockerCommands extends \Robo\Tasks
      */
     public function url()
     {
-        throw new \Exception(DKTL_DOCKER_PHP_ERROR);
+        throw new \Exception(self::DKTL_DOCKER_PHP_ERROR);
     }
 
     /**
@@ -46,7 +46,7 @@ class DockerCommands extends \Robo\Tasks
      */
     public function surl()
     {
-        throw new \Exception(DKTL_DOCKER_PHP_ERROR);
+        throw new \Exception(self::DKTL_DOCKER_PHP_ERROR);
     }
 
     /**
@@ -54,7 +54,7 @@ class DockerCommands extends \Robo\Tasks
      */
     public function uli()
     {
-        throw new \Exception(DKTL_DOCKER_PHP_ERROR);
+        throw new \Exception(self::DKTL_DOCKER_PHP_ERROR);
     }
 
     /**
@@ -62,6 +62,6 @@ class DockerCommands extends \Robo\Tasks
      */
     public function suli()
     {
-        throw new \Exception(DKTL_DOCKER_PHP_ERROR);
+        throw new \Exception(self::DKTL_DOCKER_PHP_ERROR);
     }
 }


### PR DESCRIPTION
Getting PHP error when running `dktl uli` with DKTL_MODE set to 'HOST'. I suspect this is due to the PHP being version 7.2.

![image](https://user-images.githubusercontent.com/1914306/81559821-0c55b400-9388-11ea-8908-2127fe393902.png)

This is a small patch to show the exception message correctly.