### PR TITLE
Fix mistakes in refactored make command

### DIFF
--- a/src/Drupal/V7/MakeCommands.php
+++ b/src/Drupal/V7/MakeCommands.php
@@ -189,9 +189,9 @@ class MakeCommands extends \Robo\Tasks
     /**
      * Link src/modules to  docroot/sites/all/modules/custom.
      */
-    private function linkSrcSitesAll($original, $test)
+    private function linkSrcSitesAll($original, $dest)
     {
-        if (!file_exists($original) || !file_exists('docroot')) {
+        if (!file_exists("src/$original") || !file_exists('docroot')) {
             $this->io()->error("Could not link {$original}. " .
                 "Folders 'src/{$original}' and 'docroot' must both be present to create link.");
             exit;


### PR DESCRIPTION
Not sure how this wasn't noticed till now, but recent push to fix code style issues broke one of the link functions in the 1.x make command. Just some silly mistakes.