### PR TITLE
DKAN Frontend module name is `frontend`

### DIFF
--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -54,9 +54,9 @@ class FrontendCommands extends Tasks
 
         $this->io()->note(
             'In order for the frontend to find the correct routes to work correctly,' .
-            'you will need to enable the dkan_frontend module. ' .
+            'you will need to enable the dkan frontend module. ' .
             'Do this by running "dktl install" with the "--frontend" or "--demo" option as well, ' .
-            'or else run "drush en dkan_frontend" after installation.'
+            'or else run "drush en frontend" after installation.'
         );
 
         $this->io()->note(

--- a/src/Command/InstallCommands.php
+++ b/src/Command/InstallCommands.php
@@ -31,7 +31,7 @@ class InstallCommands extends Tasks
         }
         if ($opts['frontend'] === true) {
             $result = $this->taskExec('drush en -y')
-                ->arg('dkan_frontend')
+                ->arg('frontend')
                 ->dir(Util::getProjectDocroot())
                 ->run();
         }


### PR DESCRIPTION
I'm able to consistently reproduce the following error running `dktl install --frontend` 

`Unable to install modules dkan_frontend due to missing modules dkan_frontend.`

![image](https://user-images.githubusercontent.com/1914306/81882115-ccf6b580-9589-11ea-89ad-07ea6793f4db.png)

Looking at the new dkan code, it seems like the wanted Dkan module name is `frontend`, not `dkan_frontend`.

Using the correct name fixes the issue:

![image](https://user-images.githubusercontent.com/1914306/81882658-2ca19080-958b-11ea-94f5-3dd9331fe19d.png)
