### PR TITLE
Make deploy script work with dkan2 instances

### DIFF
--- a/assets/script/deploy.sh
+++ b/assets/script/deploy.sh
@@ -14,11 +14,11 @@ fi
 DOCROOT=$1
 ENV=$2
 
-drush --root=$DOCROOT rr
-drush --root=$DOCROOT cc all
-drush --root=$DOCROOT en environment -y
-drush --root=$DOCROOT en environment_indicator -y
-drush --root=$DOCROOT en dkan_environment -y
-drush --root=$DOCROOT env-switch $ENV --force
-drush --root=$DOCROOT updb -y
-[ -f $DOCROOT/../src/script/deploy.custom.sh ] && $DOCROOT/../src/script/deploy.custom.sh $DOCROOT $ENV || echo "No custom deployment script."
+drush --root="$DOCROOT" cr
+drush --root="$DOCROOT" updb -y
+
+if [ -f "$DOCROOT"/../src/script/deploy.custom.sh ]; then
+  "$DOCROOT"/../src/script/deploy.custom.sh "$DOCROOT" "$ENV"
+else
+  echo "No custom deployment script."
+fi


### PR DESCRIPTION
`dktl deploy <env>` does not work with dkan2. Most of the steps are Drupal 7 specific or require features that are not in dkan2 (yet?).

![image](https://user-images.githubusercontent.com/1914306/81884808-c0c22680-9590-11ea-93d9-2448ba49c587.png)

This PR cleans up the `deploy.sh` script to the simplest list of commands needed to re-deploy a dkan2 instance.

Also small tweak to make the script more readable, and fix couple warnings raised by [shellcheck](https://www.shellcheck.net/) (variable quoting).