### PR TITLE
Support AWS_PROFILE env variable

### DIFF
--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -55,6 +55,7 @@ services:
       - DKTL_DOCKER=1
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - AWS_PROFILE
       - PROXY_DOMAIN
       - PLATFORM
       - XDEBUG_CONFIG=idekey=PHPSTORM


### PR DESCRIPTION
Since we already mount the `~/.aws` directory onto the container. We can simply set the `AWS_PROFILE` variable in the host to make the AWS commands work.