### PR TITLE
Support AWS_PROFILE environment variable (1.x)

### DIFF
--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -55,6 +55,7 @@ services:
       - DKTL_DOCKER=1
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - AWS_PROFILE
       - PROXY_DOMAIN
       - PLATFORM
       - XDEBUG_CONFIG=idekey=PHPSTORM


### PR DESCRIPTION
Currently, the dkan-tools sources the AWS credentials by
1. Reading credentials directly from environment variables (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY).
2. Mounting `~/.aws` directory, and sourcing the default AWS profile set.

When having no default AWS profile, we can't connect to S3 except by setting the credentials env variables, despite those being already available in the `~/.aws` directory.

With this change, we can use the standard AWS cli way of specifying which profile to load using the `AWS_PROFILE` env variable from the host.