### PR TITLE
1.x - Use new images with PHP 7.3 support

### DIFF
--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   web:
     hostname: web
-    image: getdkan/dkan-docker:php72-web
+    image: getdkan/dkan-web:classic
     ports:
       - "80"
       - "443"
@@ -49,7 +49,7 @@ services:
   # Used for all console commands and tools.
   cli:
     hostname: cli
-    image: getdkan/dkan-docker:php72-cli
+    image: getdkan/dkan-cli:classic
     environment:
       - DKTL_MODE=HOST
       - DKTL_DOCKER=1


### PR DESCRIPTION
connects NuCivic/dkan_management#338
connects GetDKAN/dkan2#366

Requires https://github.com/GetDKAN/dkan-cli/pull/1
Requires https://hub.docker.com/repository/docker/getdkan/dkan-web/tags have `latest` tag.
Requires https://hub.docker.com/repository/docker/getdkan/dkan-cli/tags have `classic` tag.

Use new Dkan specific docker images with PHP 7.3 Supports