### PR TITLE
Volume mount for local gitconfig

### DIFF
--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -79,6 +79,8 @@ services:
       - ~/.ssh:/root/.ssh
       - ~/.aws:/root/.aws
       - composer:/root/.composer
+      # Share git configuration
+      - ~/.gitconfig:/root/.gitconfig
     labels:
       - traefik.enable=false
     network_mode: bridge


### PR DESCRIPTION
Assuming someone has a ~/.gitconfig file, this will mount it in /root on cli allowing you to use git with your normal username.

If you don't have a ~/.gitconfig though, git will fail on cli because it will create a volume mount folder instead of mounting the existing file. Perhaps there is a better way to accomplish this.