### PR TITLE
Use data-catalog-react as the default frontend repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ dktl make
       * `--prefer-source` If you are working directly on the DKAN project or one of its libraries and want to be able to commit changes and submit pull requests. This option will be passed directly to Composer; see the [Composer CLI documentation](https://getcomposer.org/doc/03-cli.md#command-line-interface-commands) for more details.
       * `--tag=<tag>` To build a site using a specific DKAN tag rather than from master.
       * `--branch=<branch-name>` Similarly, you can build a specific branch of DKAN by using this option.
-      * `--frontend` **Downloads** the React frontend application (data-catalog-frontend) to _src/frontend_, installs its dependencies, and symlinks the files to _docroot/data-catalog-frontend_.
+      * `--frontend` **Downloads** the default React frontend application (data-catalog-react) to _src/frontend_, installs its dependencies, and symlinks the files to _docroot/data-catalog-frontend_.
       * `--frontend=<branch-name>` Same as above but will use the specified branch from data-catalog-frontend.
+      * `--fe-repo=<https://githbub.com/org/repo.git>` Pass a remote url to specify an alternate frontend application.
 
 5. Install DKAN. Creates a database, installs Drupal, enables DKAN.
 

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -38,7 +38,7 @@ class BasicCommands extends Tasks
      *   Convert PSR-0/4 autoloading to classmap to get a faster autoloader.
      * @option frontend
      *   - Build with the DKAN frontend application.
-     *   - You may specify which data-catalog-frontend branch to build, defaults to master.
+     *   - You may specify which data-catalog-react branch to build, defaults to master.
      * @option tag
      *   Specify DKAN tagged release to build.
      * @option branch

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -53,7 +53,7 @@ class BasicCommands extends Tasks
         'no-dev' => false,
         'optimize-autoloader' => false,
         'frontend' => null,
-        'fe-repo' => null,
+        'fe-repo' => 'https://github.com/GetDKAN/data-catalog-react.git',
         'tag' => null,
         'branch' => null,
         ])
@@ -61,15 +61,11 @@ class BasicCommands extends Tasks
         $this->io()->section("Running dktl make");
 
         // Check frontend repo value.
-        if ($opts['fe-repo']) {
-            if ($this->isValidUrl($opts['fe-repo'])) {
-                $repo = $opts['fe-repo'];
-            } else {
-                $this->io()->error($opts['fe-repo'] . " is not a valid url.");
-                exit;
-            }
+        if ($opts['fe-repo'] && $this->isValidUrl($opts['fe-repo'])) {
+            $repo = $opts['fe-repo'];
         } else {
-            $repo = 'https://github.com/GetDKAN/data-catalog-react.git';
+            $this->io()->error($opts['fe-repo'] . " is not a valid url.");
+            exit;
         }
 
         // Add project dependencies.

--- a/src/Command/BasicCommands.php
+++ b/src/Command/BasicCommands.php
@@ -62,16 +62,14 @@ class BasicCommands extends Tasks
 
         // Check frontend repo value.
         if ($opts['fe-repo']) {
-          if ($this->isValidUrl($opts['fe-repo'])) {
-            $repo = $opts['fe-repo'];
-          }
-          else {
-            $this->io()->error($opts['fe-repo'] . " is not a valid url.");
-            exit;
-          }
-        }
-        else {
-          $repo = 'https://github.com/GetDKAN/data-catalog-react.git';
+            if ($this->isValidUrl($opts['fe-repo'])) {
+                $repo = $opts['fe-repo'];
+            } else {
+                $this->io()->error($opts['fe-repo'] . " is not a valid url.");
+                exit;
+            }
+        } else {
+            $repo = 'https://github.com/GetDKAN/data-catalog-react.git';
         }
 
         // Add project dependencies.
@@ -221,17 +219,15 @@ class BasicCommands extends Tasks
 
     public function isValidUrl($url)
     {
-      // first do some quick sanity checks:
-      if (!$url || !is_string($url)) {
-          return false;
-      }
-      // quick check url is roughly a valid http request: ( http://blah/... )
-      if ( ! preg_match('/^http(s)?:\/\/[a-z0-9-]+(\.[a-z0-9-]+)*(:[0-9]+)?(\/.*)?$/i', $url) ) {
-
-          return false;
-      }
-
-      // good enough!
-      return true;
-  }
+        // Quick sanity checks.
+        if (!$url || !is_string($url)) {
+            return false;
+        }
+        // Url is roughly a valid http request.
+        if (!preg_match('/^http(s)?:\/\/[a-z0-9-]+(\.[a-z0-9-]+)*(:[0-9]+)?(\/.*)?$/i', $url)) {
+            return false;
+        }
+        // Good enough!
+        return true;
+    }
 }

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -25,7 +25,7 @@ class DkanCommands extends \Robo\Tasks
             ->run();
 
             return $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
-            ->dir("{$proj_dir}/docroot/data-catalog-frontend")
+            ->dir("{$proj_dir}/docroot/frontend")
             ->run();
         }
 

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -21,7 +21,7 @@ class DkanCommands extends \Robo\Tasks
 
         if ($arg === 'frontend') {
             $this->taskExec("npm install cypress")
-            ->dir("{$proj_dir}/docroot/data-catalog-frontend")
+            ->dir("{$proj_dir}/docroot/frontend")
             ->run();
 
             return $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -17,7 +17,7 @@ class FrontendCommands extends Tasks
         $result = $this->taskExec('git clone')
             ->option('depth', '1')
             ->option('-b', $branch)
-            ->arg('https://github.com/GetDKAN/data-catalog-frontend.git')
+            ->arg('https://github.com/GetDKAN/data-catalog-react.git')
             ->arg('frontend')
             ->dir('src')
             ->run();
@@ -43,12 +43,12 @@ class FrontendCommands extends Tasks
      */
     public function frontendLink()
     {
-        $result = $this->taskExec('ln -s ../src/frontend data-catalog-frontend')
+        $result = $this->taskExec('ln -s ../src/frontend frontend')
           ->dir("docroot")
           ->run();
         if ($result && $result->getExitCode() === 0) {
             $this->io()->success(
-                'Successfully symlinked /src/frontend to docroot/data-catalog-frontend'
+                'Successfully symlinked /src/frontend to docroot/frontend'
             );
         }
 

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -10,14 +10,17 @@ class FrontendCommands extends Tasks
   /**
    * Get frontend app.
    */
-    public function frontendGet($branch = 'master')
+    public function frontendGet($repo = 'https://github.com/GetDKAN/data-catalog-react.git', $branch = 'master')
     {
         $this->io()->section('Adding frontend application');
+
+        $a = explode('/', $repo);
+        $name = str_replace('.git', '', end($a));
 
         $result = $this->taskExec('git clone')
             ->option('depth', '1')
             ->option('-b', $branch)
-            ->arg('https://github.com/GetDKAN/data-catalog-react.git')
+            ->arg($repo)
             ->arg('frontend')
             ->dir('src')
             ->run();
@@ -31,7 +34,7 @@ class FrontendCommands extends Tasks
 
         if ($result && $result->getExitCode() === 0) {
             $this->io()->note(
-                'Successfully downloaded data-catalog-frontend to /src/frontend'
+                'Successfully downloaded ' . $name . ' to /src/frontend'
             );
         }
 


### PR DESCRIPTION
Using a Gatsby-based frontend is not working out as planned. Switching to a Create REACT App-bassed frontend will provide less confusion and rebuilding for dynamic content.

- Changed the symlinked directory in Docroot to 'frontend'
- Add option to use alternate frontend applications by passing the url of the repo

## QA steps

- run `dktl make --frontend`, confirm you get the data-catalog-react repo symlinked to docroot/frontend
- delete src/frontend
- run `dktl make --frontend --fe-repo=https://github.com/GetDKAN/data-catalog-frontend.git`, confirm you get the gatsby version