### PR TITLE
Add command for DKTL self-testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,5 +34,5 @@ jobs:
             export PATH=$PATH:~/project/bin
             cd ~/project
             dktl init
-            dktl dc exec cli ./vendor/bin/phpunit
+            dktl test:dktl
 

--- a/src/Command/TestCommands.php
+++ b/src/Command/TestCommands.php
@@ -20,4 +20,18 @@ class TestCommands extends \Robo\Tasks
             throw new \Exception("Cypress tests failed.");
         }
     }
+
+    /**
+     * Run dkan-tools' own suite of unit tests.
+     */
+    public function testDktl()
+    {
+        $dktlDir = Util::getDktlDirectory();
+        $result = $this->taskExec("{$dktlDir}/vendor/bin/phpunit")
+            ->dir($dktlDir)
+            ->run();
+        if ($result->getExitCode() != 0) {
+            throw new \Exception("DKTL unit tests failed.");
+        }
+    }
 }


### PR DESCRIPTION
This adds a command `dktl test:dktl` to run DKTL's own internal test suite, and runs it in CircleCI.

Not sure that's really the right place for such a command; open to other suggestions.

## QA Steps

- Tests on this PR should execute and fail
- Commit status should show failed due to tests (not another build error)