### PR TITLE
Change Cypress base url from web to $DKTL_PROXY_DOMAIN

### DIFF
--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -24,7 +24,7 @@ class DkanCommands extends \Robo\Tasks
             ->dir("{$proj_dir}/docroot/data-catalog-frontend")
             ->run();
 
-            return $this->taskExec("CYPRESS_baseUrl=http://web npx cypress run")
+            return $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
             ->dir("{$proj_dir}/docroot/data-catalog-frontend")
             ->run();
         }
@@ -33,7 +33,7 @@ class DkanCommands extends \Robo\Tasks
         ->dir("{$proj_dir}/docroot/modules/contrib/dkan")
         ->run();
 
-        return $this->taskExec("CYPRESS_baseUrl=http://web npx cypress run")
+        return $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
             ->dir("{$proj_dir}/docroot/modules/contrib/dkan")
             ->run();
     }


### PR DESCRIPTION
Fixes GetDKAN/dkan-catalog-frontend#57

When comparing urls in the frontend we are building using `$DKTL_PROXY_DOMAIN` but the Cypress tests set the base url to web. This causes the dataset file download test to fail as `web` does not match with `sandbox.localtest.me` in the Gatsby code.  

QA:
In a DKAN instance
1. `dktl make --frontend=cypress-updates-07-24` This branch has passing tests for the Gatsby build.
1. `dktl install --demo` The data used for the frontend Cypress tests.
1. `dktl drush user:create testuser --password="2jqzOAnXS9mmcLasy"` Users needed for backend Cypress tests.
1. `dktl drush user-add-role api_user testuser`
1. `dktl drush user:create testeditor --password="testeditor"`
1. `dktl drush user-add-role administrator testeditor`
1. `dktl dkan:test-cypress` Test Cypress Backend
1. `dktl dkan:test-cypress frontend` Test Cypress Frontend
