### PR TITLE
Enable basic HTTPS support

### DIFF
--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -13,7 +13,8 @@ services:
       - "${DKTL_DIRECTORY}/assets/docker/mysql.env"
     environment:
       - DKTL_DOCKER=1
-      - DKTL_PROXY_DOMAIN
+      - DKTL_PROJECT_DOMAIN
+      - DKTL_PROJECT_URL
 
   # DB node
   db:
@@ -39,7 +40,8 @@ services:
       - NODE_ENV=development
       - DKTL_MODE=HOST
       - DKTL_DOCKER=1
-      - DKTL_PROXY_DOMAIN
+      - DKTL_PROJECT_DOMAIN
+      - DKTL_PROJECT_URL
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_PROFILE
@@ -47,7 +49,7 @@ services:
       - XDEBUG_CONFIG=idekey=PHPSTORM
       - XDEBUG_DKTL=1
     links:
-      - "web:${DKTL_PROXY_DOMAIN}"
+      - "web:${DKTL_PROJECT_DOMAIN}"
       # Link web to dkan for backward compatibility.
       - "web:dkan"
     ports:

--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -6,24 +6,14 @@ services:
     image: getdkan/dkan-web:v0.2.0
     ports:
       - "80"
-      - "443"
-      - "8888"
     volumes:
       # PHP configuration overrides
       - "${DKTL_PROJECT_DIRECTORY}:/var/www/:delegated"
     env_file:
       - "${DKTL_DIRECTORY}/assets/docker/mysql.env"
     environment:
-      # no_proxy="" required for default Docker For Mac system proxy that contains a space and prevents Selenium from loading.
-      # Linked containers to browser will also need this setting.
-      - PROXY_DOMAIN
       - DKTL_DOCKER=1
-      - no_proxy=localhost
-    labels:
-      - "traefik.enable=true"
-      - "traefik.frontend.passHostHeader=true"
-      - "traefik.http.routers.${DKTL_SLUG}-web.rule=Host(`${DKTL_PROXY_DOMAIN}`)"
-      - "traefik.http.routers.${DKTL_SLUG}-web.entrypoints=web"
+      - DKTL_PROXY_DOMAIN
 
   # DB node
   db:

--- a/assets/docker/docker-compose.nossl.yml
+++ b/assets/docker/docker-compose.nossl.yml
@@ -4,5 +4,5 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.passHostHeader=true"
-      - "traefik.http.routers.${DKTL_SLUG}-web.rule=Host(`${DKTL_PROXY_DOMAIN}`)"
+      - "traefik.http.routers.${DKTL_SLUG}-web.rule=Host(`${DKTL_PROJECT_DOMAIN}`)"
       - "traefik.http.routers.${DKTL_SLUG}-web.entrypoints=web"

--- a/assets/docker/docker-compose.nossl.yml
+++ b/assets/docker/docker-compose.nossl.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  web:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.frontend.passHostHeader=true"
+      - "traefik.http.routers.${DKTL_SLUG}-web.rule=Host(`${DKTL_PROXY_DOMAIN}`)"
+      - "traefik.http.routers.${DKTL_SLUG}-web.entrypoints=web"

--- a/assets/docker/docker-compose.ssl.yml
+++ b/assets/docker/docker-compose.ssl.yml
@@ -4,7 +4,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.passHostHeader=true"
-      - "traefik.http.routers.${DKTL_SLUG}-web.rule=Host(`${DKTL_PROXY_DOMAIN}`)"
+      - "traefik.http.routers.${DKTL_SLUG}-web.rule=Host(`${DKTL_PROJECT_DOMAIN}`)"
       - "traefik.http.routers.${DKTL_SLUG}-web.entrypoints=websecure"
       - "traefik.http.routers.${DKTL_SLUG}-web.tls.certresolver=letsencrypt"
       - "traefik.docker.network=${DKTL_SLUG}_default"

--- a/assets/docker/docker-compose.ssl.yml
+++ b/assets/docker/docker-compose.ssl.yml
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  web:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.frontend.passHostHeader=true"
+      - "traefik.http.routers.${DKTL_SLUG}-web.rule=Host(`${DKTL_PROXY_DOMAIN}`)"
+      - "traefik.http.routers.${DKTL_SLUG}-web.entrypoints=websecure"
+      - "traefik.http.routers.${DKTL_SLUG}-web.tls.certresolver=letsencrypt"
+      - "traefik.docker.network=${DKTL_SLUG}_default"

--- a/assets/docker/docker-compose.ssl.yml
+++ b/assets/docker/docker-compose.ssl.yml
@@ -6,5 +6,4 @@ services:
       - "traefik.frontend.passHostHeader=true"
       - "traefik.http.routers.${DKTL_SLUG}-web.rule=Host(`${DKTL_PROJECT_DOMAIN}`)"
       - "traefik.http.routers.${DKTL_SLUG}-web.entrypoints=websecure"
-      - "traefik.http.routers.${DKTL_SLUG}-web.tls.certresolver=letsencrypt"
-      - "traefik.docker.network=${DKTL_SLUG}_default"
+      - "traefik.http.routers.${DKTL_SLUG}-web.tls=true"

--- a/assets/site/settings.docker.php
+++ b/assets/site/settings.docker.php
@@ -15,6 +15,6 @@ if (getenv("DKTL_DOCKER") == "1") {
         ],
     ];
 
-    $proxy_domain = getenv('DKTL_PROXY_DOMAIN');
-    $settings['file_public_base_url'] = "http://$proxy_domain/sites/default/files";
+    $url = getenv('DKTL_PROJECT_URL');
+    $settings['file_public_base_url'] = $url . "/sites/default/files";
 }

--- a/bin/dktl
+++ b/bin/dktl
@@ -4,6 +4,9 @@
 # DKAN-tools bash script.                                                      #
 ################################################################################
 
+DKTL_SSL=false
+DKTL_SSL_MAIL="null@example.com"
+
 # Primary workflow for dktl command. Executed on last line of script.
 main() {
   set_mode
@@ -160,11 +163,21 @@ docker_vars_init() {
   fi
 
   COMMON_CONF="$DKTL_DIRECTORY/assets/docker/docker-compose.common.yml"
+  NOSSL_CONF="$DKTL_DIRECTORY/assets/docker/docker-compose.nossl.yml"
+  SSL_CONF="$DKTL_DIRECTORY/assets/docker/docker-compose.ssl.yml"
+
   OVERRIDES_CONF="$DKTL_PROJECT_DIRECTORY/src/docker/docker-compose.overrides.yml"
+
   BASE_DOCKER_COMPOSE_COMMAND="docker-compose \
     --file $COMMON_CONF \
     --project-name "${DKTL_SLUG}" \
     --project-directory $DKTL_PROJECT_DIRECTORY"
+
+  if [ "$DKTL_SSL" = true ]; then
+    BASE_DOCKER_COMPOSE_COMMAND+=" -f $SSL_CONF"
+  else
+    BASE_DOCKER_COMPOSE_COMMAND+=" -f $NOSSL_CONF"
+  fi
 
   if [ -f $OVERRIDES_CONF ]; then
     BASE_DOCKER_COMPOSE_COMMAND+=" -f $OVERRIDES_CONF"
@@ -217,16 +230,30 @@ proxy_setup() {
     echo "Running dktl-proxy.."
     # Make sure no old instance is using the name.
     docker rm dktl-proxy >/dev/null 2>&1
-    if ! docker run -d -p 8080:8080 -p 80:80 -p 433:433 \
+
+    TRAEFIK_CMD="docker run -d \
+      -p 8080:8080 -p 80:80 -p 443:443 \
       -v '/var/run/docker.sock:/var/run/docker.sock' \
       --name 'dktl-proxy' \
-      traefik:v2.0 \
-      --log.level=INFO --api.insecure=true --providers.docker=true \
-      --providers.docker.exposedbydefault=false --entrypoints.web.address=:80 \
-      --entrypoints.websecure.address=:443 \
+      traefik:v2.0"
+
+    TRAEFIK_OPTS=" --log.level=INFO \
+      --providers.docker=true --providers.docker.exposedbydefault=false \
+      --entrypoints.web.address=:80 \
+      --entrypoints.websecure.address=:443"
+
+    if [ $DKTL_SSL ]; then
+      TRAEFIK_OPTS+=" --certificatesresolvers.letsencrypt.acme.tlschallenge=true \
+      --certificatesResolvers.letsencrypt.acme.email=$DKTL_SSL_MAIL \
+      --certificatesResolvers.letsencrypt.acme.storage=acme.json"
+    fi
+
+    if ! "$TRAEFIK_CMD" "$TRAEFIK_OPTS" \
       >/dev/null; \
     then
       echo -n "Failed to start the dktl-proxy container..."
+    else
+      echo -n "dktl-proxy started successfully..."
     fi
 
   fi

--- a/bin/dktl
+++ b/bin/dktl
@@ -154,13 +154,20 @@ set_slug() {
 }
 
 # Set the following variables for use with docker-compose commands:
-# DKTL_PROXY_DOMAIN, BASE_DOCKER_COMPOSE_COMMAND, EXEC_OPTS
+# DKTL_PROJECT_DOMAIN, BASE_DOCKER_COMPOSE_COMMAND, EXEC_OPTS
 docker_vars_init() {
-  if [ -z $WEB_DOMAIN ]; then
-    WEB_DOMAIN="localtest.me"
+  if [ -z $DKTL_BASE_DOMAIN ]; then
+    DKTL_BASE_DOMAIN="localtest.me"
   fi
-  if [ -z $DKTL_PROXY_DOMAIN ]; then
-    export DKTL_PROXY_DOMAIN="$DKTL_SLUG.$WEB_DOMAIN"
+
+  if [ -z $DKTL_PROJECT_DOMAIN ]; then
+    export DKTL_PROJECT_DOMAIN="$DKTL_SLUG.$DKTL_BASE_DOMAIN"
+  fi
+
+  if [ "$DKTL_SSL" = true ]; then
+    export DKTL_PROJECT_URL="https://$DKTL_SLUG.$DKTL_BASE_DOMAIN"
+  else
+    export DKTL_PROJECT_URL="http://$DKTL_SLUG.$DKTL_BASE_DOMAIN"
   fi
 
   COMMON_CONF="$DKTL_DIRECTORY/assets/docker/docker-compose.common.yml"
@@ -266,7 +273,8 @@ docker_command_intercept() {
     $BASE_DOCKER_COMPOSE_COMMAND "${@:2}"
     exit 0
   elif [ "$1" = "url" ] || [ "$1" = "docker:url" ]; then
-    echo "http://$DKTL_PROXY_DOMAIN"
+
+    echo $DKTL_PROJECT_URL
     exit 0
   elif [ "$1" = "down" ]; then
     dc_down

--- a/bin/dktl
+++ b/bin/dktl
@@ -5,8 +5,8 @@
 ################################################################################
 
 ## Supported env variables:
-# DKTL_SSL=false
-# DKTL_SSL_MAIL="null@example.com"
+# DKTL_SSL: Enable HTTPS acroos (all) environements. default to false.
+DKTL_SSL=${DKTL_SSL:-false}
 
 # Primary workflow for dktl command. Executed on last line of script.
 main() {
@@ -164,7 +164,7 @@ docker_vars_init() {
     export DKTL_PROJECT_DOMAIN="$DKTL_SLUG.$DKTL_BASE_DOMAIN"
   fi
 
-  if [ "$DKTL_SSL" = true ]; then
+  if [ "$DKTL_SSL" == true ]; then
     export DKTL_PROJECT_URL="https://$DKTL_SLUG.$DKTL_BASE_DOMAIN"
   else
     export DKTL_PROJECT_URL="http://$DKTL_SLUG.$DKTL_BASE_DOMAIN"
@@ -181,7 +181,7 @@ docker_vars_init() {
     --project-name "${DKTL_SLUG}" \
     --project-directory $DKTL_PROJECT_DIRECTORY"
 
-  if [ "$DKTL_SSL" = true ]; then
+  if [ "$DKTL_SSL" == true ]; then
     BASE_DOCKER_COMPOSE_COMMAND+=" -f $SSL_CONF"
   else
     BASE_DOCKER_COMPOSE_COMMAND+=" -f $NOSSL_CONF"
@@ -249,12 +249,6 @@ proxy_setup() {
       --providers.docker=true --providers.docker.exposedbydefault=false \
       --entrypoints.web.address=:80 \
       --entrypoints.websecure.address=:443"
-
-    if [ "$DKTL_SSL" = true ]; then
-      TRAEFIK_OPTS+=" --certificatesresolvers.letsencrypt.acme.tlschallenge=true \
-      --certificatesResolvers.letsencrypt.acme.email=$DKTL_SSL_MAIL \
-      --certificatesResolvers.letsencrypt.acme.storage=acme.json"
-    fi
 
     if ! $TRAEFIK_CMD $TRAEFIK_OPTS >/dev/null; \
     then

--- a/bin/dktl
+++ b/bin/dktl
@@ -4,8 +4,9 @@
 # DKAN-tools bash script.                                                      #
 ################################################################################
 
-DKTL_SSL=false
-DKTL_SSL_MAIL="null@example.com"
+## Supported env variables:
+# DKTL_SSL=false
+# DKTL_SSL_MAIL="null@example.com"
 
 # Primary workflow for dktl command. Executed on last line of script.
 main() {
@@ -233,8 +234,8 @@ proxy_setup() {
 
     TRAEFIK_CMD="docker run -d \
       -p 8080:8080 -p 80:80 -p 443:443 \
-      -v '/var/run/docker.sock:/var/run/docker.sock' \
-      --name 'dktl-proxy' \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      --name dktl-proxy \
       traefik:v2.0"
 
     TRAEFIK_OPTS=" --log.level=INFO \
@@ -242,18 +243,17 @@ proxy_setup() {
       --entrypoints.web.address=:80 \
       --entrypoints.websecure.address=:443"
 
-    if [ $DKTL_SSL ]; then
+    if [ "$DKTL_SSL" = true ]; then
       TRAEFIK_OPTS+=" --certificatesresolvers.letsencrypt.acme.tlschallenge=true \
       --certificatesResolvers.letsencrypt.acme.email=$DKTL_SSL_MAIL \
       --certificatesResolvers.letsencrypt.acme.storage=acme.json"
     fi
 
-    if ! "$TRAEFIK_CMD" "$TRAEFIK_OPTS" \
-      >/dev/null; \
+    if ! $TRAEFIK_CMD $TRAEFIK_OPTS >/dev/null; \
     then
-      echo -n "Failed to start the dktl-proxy container..."
+      echo "Failed to start the dktl-proxy container..."
     else
-      echo -n "dktl-proxy started successfully..."
+      echo "dktl-proxy started successfully..."
     fi
 
   fi

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -36,7 +36,7 @@ class DkanCommands extends \Robo\Tasks
             ->dir("docroot/modules/contrib/dkan")
             ->run();
 
-        return $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
+        return $this->taskExec('CYPRESS_baseUrl="$DKTL_PROJECT_URL" npx cypress run')
             ->dir("docroot/modules/contrib/dkan")
             ->run();
     }

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -212,7 +212,7 @@ class FrontendCommands extends Tasks
         ->dir("docroot/frontend")
         ->run();
 
-        return $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
+        return $this->taskExec('CYPRESS_baseUrl="$DKTL_PROJECT_URL" npx cypress run')
             ->dir("docroot/frontend")
             ->run();
     }

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -18,7 +18,7 @@ class Util
 
     public static function getDktlProxyDomain()
     {
-        if ($proxy = getenv("DKTL_PROXY_DOMAIN")) {
+        if ($proxy = getenv("DKTL_PROJECT_DOMAIN")) {
             return $proxy;
         } else {
             return '';
@@ -37,10 +37,7 @@ class Util
 
     public static function getUri()
     {
-        $domain = getenv("DKTL_PROXY_DOMAIN");
-        if ($domain) {
-            $domain = "http://" . $domain;
-        }
+        $domain = getenv("DKTL_PROJECT_URL");
         return $domain;
     }
 


### PR DESCRIPTION
**How to use**
```
$ export DKTL_SSL=true # Enable SSL support in dktl, this will affect all dktl commands ran in this shell!
$ dktl init
$ dktl demo
```
should get an https site that works.