### PR TITLE
Add option for local DKAN

### DIFF
--- a/bin/dktl
+++ b/bin/dktl
@@ -26,17 +26,17 @@ dktl_run() {
     # Check whether dkan-tools' dependencies have been initialized.
     if [ -z "$(ls -lha $DKTL_DIRECTORY | grep vendor)" ]; then
       echo "Composer Install"
-      composer install --working-dir=$DKTL_DIRECTORY    
+      composer install --working-dir=$DKTL_DIRECTORY
     fi
 
     # Finally, execute the php app.
     case $1 in
         # Pass through arguments for these. See: https://bit.ly/30IlWGk
         drush | phpunit | *test* )
-            php $DKTL_DIRECTORY/bin/app.php $1 -- "${@:2}"
+            php "$DKTL_DIRECTORY"/bin/app.php $1 -- "${@:2}"
             ;;
         *)
-            php $DKTL_DIRECTORY/bin/app.php $1 "${@:2}"
+            php "$DKTL_DIRECTORY"/bin/app.php $1 "${@:2}"
             ;;
     esac
 
@@ -53,7 +53,7 @@ dktl_docker_run() {
   # Proxy-pass to docker and save exit status. The command will re-
   # run in host mode inside the cli container, so dktl_run will still
   # ultimately be run whichever mode dktl is set to. 
-  $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli dktl "$1" "${@:2}"
+  dc_base exec $EXEC_OPTS cli dktl "$1" "${@:2}"
   exit_status=$?
 
   dktl_docker_cleanup "$@"
@@ -131,9 +131,10 @@ set_directory() {
   if [[ -L $(which dktl) ]]; then
     # readlink command needs -f to work properly in linux
     if [ "$PLATFORM" = "Linux" ]; then RL_OPT='-f'; fi;
-    DKTL_DIRECTORY=$(readlink $RL_OPT $DKTL_DIRECTORY)
+    DKTL_DIRECTORY=$(readlink $RL_OPT "$DKTL_DIRECTORY")
   fi
-  DKTL_DIRECTORY=$(dirname $(dirname $DKTL_DIRECTORY))
+  DKTL_DIRECTORY=$(dirname "$DKTL_DIRECTORY")
+  DKTL_DIRECTORY=$(dirname "$DKTL_DIRECTORY")
   export DKTL_DIRECTORY
 }
 
@@ -161,14 +162,6 @@ docker_vars_init() {
 
   COMMON_CONF="$DKTL_DIRECTORY/assets/docker/docker-compose.common.yml"
   OVERRIDES_CONF="$DKTL_PROJECT_DIRECTORY/src/docker/docker-compose.overrides.yml"
-  BASE_DOCKER_COMPOSE_COMMAND="docker-compose \
-    --file $COMMON_CONF \
-    --project-name "${DKTL_SLUG}" \
-    --project-directory $DKTL_PROJECT_DIRECTORY"
-
-  if [ -f $OVERRIDES_CONF ]; then
-    BASE_DOCKER_COMPOSE_COMMAND+=" -f $OVERRIDES_CONF"
-  fi
 
   # Check for interactive shell if DKTL_NO_PTY is not set
   if [ ! -z "$DKTL_NO_PTY" ]; then
@@ -179,6 +172,21 @@ docker_vars_init() {
     EXEC_OPTS='-T';
   fi
 }
+
+dc_base() {
+  dc=( docker-compose \
+    --file "$COMMON_CONF" \
+    --project-name $DKTL_SLUG \
+    --project-directory "$DKTL_PROJECT_DIRECTORY" )
+
+  if [ -f "$OVERRIDES_CONF" ]; then
+    dc+=( --file "$OVERRIDES_CONF" )
+  fi
+
+  dc+=( "$@" )
+  "${dc[@]}"
+}
+
 
 # Set up subdomain with traefic proxy.
 proxy_connect () {
@@ -191,11 +199,10 @@ proxy_connect () {
 dc_up () {
   # Check containers state, Run is missing, make sure dktl-proxy is connected
   # to the same network.
-  containers=$($BASE_DOCKER_COMPOSE_COMMAND ps -q)
+  containers=$(dc_base ps -q)
   if [ -z "$containers" ]; then
     echo "Starting docker containers."
-    $BASE_DOCKER_COMPOSE_COMMAND up -d
-
+    dc_base up -d
     proxy_connect
   fi
 }
@@ -207,7 +214,7 @@ dc_down() {
     echo "Disconnected dktl-proxy from \"${network}\" network."
   fi
 
-  $BASE_DOCKER_COMPOSE_COMMAND down -v "${@:2}"
+  dc_base down -v "${@:2}"
 }
 
 # Make sure the proxy container is up.
@@ -236,7 +243,7 @@ proxy_setup() {
 docker_command_intercept() {
   if [ "$1" = "docker:compose" ] || [ "$1" = "dc" ]; then
     dc_up
-    $BASE_DOCKER_COMPOSE_COMMAND "${@:2}"
+    dc_base "${@:2}"
     exit 0
   elif [ "$1" = "url" ] || [ "$1" = "docker:url" ]; then
     echo "http://$DKTL_PROXY_DOMAIN"
@@ -247,7 +254,7 @@ docker_command_intercept() {
   elif [ "$1" = "docker:proxy-connect" ] || [ "$1" = "proxy:connect" ]; then
     proxy_connect
     # Restart container to refresh config.
-    $BASE_DOCKER_COMPOSE_COMMAND restart
+    dc_base restart
     exit 0
   elif [ "$1" = "docker:proxy-kill" ] || [ "$1" = "proxy:kill" ]; then
     echo "Removing dktl-proxy ..."
@@ -259,11 +266,11 @@ docker_command_intercept() {
 
 # The containers are running, set DKTL inside the cli container.
 dktl_set_alias() {
-  ALIAS="$($BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli which dktl)"
+  ALIAS="$(dc_base exec $EXEC_OPTS cli which dktl)"
   if [ -z "$ALIAS" ]; then
-    $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli \
+    dc_base exec $EXEC_OPTS cli \
       chmod 777 /usr/local/dkan-tools/bin/dktl
-    $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli \
+    dc_base exec $EXEC_OPTS cli \
       ln -s /usr/local/dkan-tools/bin/dktl /usr/local/bin/dktl
   fi
 }
@@ -271,20 +278,20 @@ dktl_set_alias() {
 dktl_docker_cleanup() {
   # Reset web and cli containers if xdebug.
   if [ $? -eq 0 ] && [[ $1 == "xdebug"* ]]; then
-    $BASE_DOCKER_COMPOSE_COMMAND restart web
-    $BASE_DOCKER_COMPOSE_COMMAND restart cli
+    dc_base restart web
+    dc_base restart cli
   fi
 
   # Proxy connect if we just ran make.
   if [ $? -eq 0 ] && [[ $1 == "init"* ]]; then
     proxy_connect
-    $BASE_DOCKER_COMPOSE_COMMAND restart web
+    dc_base restart web
   fi
 
   if [ -z "$DKTL_CHOWN" ] || [ "$DKTL_CHOWN" = "TRUE" ]; then
     # Docker creates files that appear as owned by root on host. Fix:
     if [ -n "$(find "$DKTL_PROJECT_DIRECTORY" -user root -print -quit)" ]; then
-        $BASE_DOCKER_COMPOSE_COMMAND exec $EXEC_OPTS cli chown -R `id -u`:`id -g` /var/www
+        dc_base exec $EXEC_OPTS cli chown -R `id -u`:`id -g` /var/www
     fi
   fi
 }

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -21,6 +21,10 @@ class InitCommands extends \Robo\Tasks
      * @option str dkan
      *   DKAN version (expressed as composer constraint). Use 2.x-dev for current
      *   bleeding edge.
+     * @option bool dkan-local
+     *   Use DKAN from a "dkan" folder in your project root instead of composer.
+     *   You may encounter problems if you are using a development branch and
+     *   don't pass "--dkan dev-yourbranch" as well.
     */
     public function init($opts = ['drupal' => '9.0.0', 'dkan' => null, 'dkan-local' => false])
     {
@@ -238,7 +242,10 @@ class InitCommands extends \Robo\Tasks
             ->run();
     }
 
-    public function initLocalDkan()
+    /**
+     * Add composer repository for /dkan folder in project.
+     */
+    private function initLocalDkan()
     {
         $this->taskComposerConfig()
             ->repository('getdkan', 'dkan', 'path')

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -241,8 +241,7 @@ class InitCommands extends \Robo\Tasks
     public function initLocalDkan()
     {
         $this->taskComposerConfig()
-            ->arg('repositories.getdkan')
-            ->arg('{"type": "path", "url": "dkan", "symlink": false}')
+            ->repository('getdkan', 'dkan', 'path')
             ->run();
     }
 }

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -22,7 +22,7 @@ class InitCommands extends \Robo\Tasks
      *   DKAN version (expressed as composer constraint). Use 2.x-dev for current
      *   bleeding edge.
     */
-    public function init($opts = ['drupal' => '9.0.0', 'dkan' => null])
+    public function init($opts = ['drupal' => '9.0.0', 'dkan' => null, 'dkan-local' => false])
     {
         // Validate version is semantic and at least the minimum set
         // in DrupalProjectTrait.
@@ -32,6 +32,9 @@ class InitCommands extends \Robo\Tasks
         $this->initDrupal($opts['drupal']);
         $this->initConfig();
         $this->initSrc();
+        if ($opts['dkan-local']) {
+            $this->initLocalDkan();
+        }
         $this->initDkan($opts['dkan']);
     }
 
@@ -232,6 +235,13 @@ class InitCommands extends \Robo\Tasks
         $this->taskComposerRequire()
             ->dependency('getdkan/dkan', $version)
             ->option('--no-update')
+            ->run();
+    }
+
+    public function initLocalDkan()
+    {
+        $this->taskComposerConfig()
+            ->repository('getdkan', 'dkan', 'path')
             ->run();
     }
 }

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -40,7 +40,7 @@ class InitCommands extends \Robo\Tasks
             $this->initLocalDkan();
             $version = $this->localDkanVersion();
         }
-        if (isset($version)) {
+        if (isset($version) && !$opts['dkan']) {
             $opts['dkan'] = $version;
         }
         $this->initDkan($opts['dkan']);

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -35,6 +35,7 @@ class InitCommands extends \Robo\Tasks
         }
         $this->initConfig();
         $this->initSrc();
+        $this->initDrupal($opts['drupal']);
         if ($opts['dkan-local']) {
             $this->initLocalDkan();
             $version = $this->localDkanVersion();
@@ -42,7 +43,6 @@ class InitCommands extends \Robo\Tasks
         if (isset($version)) {
             $opts['dkan'] = $version;
         }
-        $this->initDrupal($opts['drupal']);
         $this->initDkan($opts['dkan']);
     }
 
@@ -243,6 +243,7 @@ class InitCommands extends \Robo\Tasks
      */
     private function initLocalDkan()
     {
+        $this->io()->section('Adding local DKAN repository in /dkan.');
         $this->taskComposerConfig()
             ->repository('getdkan', 'dkan', 'path')
             ->run();

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -241,7 +241,8 @@ class InitCommands extends \Robo\Tasks
     public function initLocalDkan()
     {
         $this->taskComposerConfig()
-            ->repository('getdkan', 'dkan', 'path')
+            ->arg('repositories.getdkan')
+            ->arg('{"type": "path", "url": "dkan", "symlink": false}')
             ->run();
     }
 }

--- a/src/DrupalProjectTrait.php
+++ b/src/DrupalProjectTrait.php
@@ -26,16 +26,17 @@ trait DrupalProjectTrait
 
     private function drupalProjectCreate(string $version)
     {
+        $projectSource = "drupal/recommended-project:{$version}";
         $createFiles = $this->taskComposerCreateProject()
-            ->source("drupal/recommended-project:{$version}")
+            ->source($projectSource)
             ->target(Util::TMP_DIR)
             ->noInstall()
             ->run();
         if ($createFiles->getExitCode() != 0) {
-            $this->io()->error('could not run composer create-project.');
+            $this->io()->error('Could not run composer create-project.');
             exit;
         }
-        $this->io()->success('composer project created.');
+        $this->io()->success("Composer project created from {$projectSource}.");
     }
 
     /**
@@ -54,7 +55,7 @@ trait DrupalProjectTrait
             $this->io()->error('could not move composer files.');
             exit;
         }
-        $this->io()->success('composer.json and composer.lock moved to project root.');
+        $this->io()->success('composer.json moved to project root.');
     }
 
     /**
@@ -62,15 +63,16 @@ trait DrupalProjectTrait
      */
     private function drupalProjectSetDocrootPath()
     {
-        $regexps = "s#web/#" . self::$drupalDocroot . "/#g";
+        $docroot = self::$drupalDocroot;
+        $regexps = "s#web/#" . $docroot . "/#g";
         $installationPaths = $this->taskExec("sed -i -E '{$regexps}'")
             ->arg('composer.json')
             ->run();
         if ($installationPaths->getExitCode() != 0) {
-            $this->io()->error('could not Unable to modifying composer.json paths.');
+            $this->io()->error('Unable to modify composer.json paths.');
             exit;
         }
-        $this->io()->success('composer installation paths modified.');
+        $this->io()->success("Composer installation paths modified to {$docroot}.");
     }
 
     /**

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -46,8 +46,7 @@ testDktlInitDrupalVersionMoreThanMaximum()
 
 testDktlInit() {
     result=`dktl init`
-    echo $result
-    assertContains "${result}" 'composer project created.'
+    assertContains "${result}" 'Composer project created'
     
     result=`ls`
     assertContains "${result}" "dktl.yml"

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -41,7 +41,7 @@ testDktlInitDrupalVersionMoreThanMaximum()
 {
     result=`dktl init --drupal=77.7.7`
     assertContains "${result}" "Could not find package drupal/recommended-project with version 77.7.7."
-    assertContains "${result}" "[ERROR] could not run composer create-project."
+    # assertContains "${result}" "could not run composer create-project."
 }
 
 testDktlInit() {

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -46,6 +46,7 @@ testDktlInitDrupalVersionMoreThanMaximum()
 
 testDktlInit() {
     result=`dktl init`
+    echo $result
     assertContains "${result}" 'composer project created.'
     
     result=`ls`


### PR DESCRIPTION
If we're using running a CI pipeline, or doing local DKAN development, we want to be able to use an existing clone of the DKAN repo rather than simply pulling it in from packagist. 

This PR adds a `--dkan-local` switch to the `dktl init` command that will add a custom repository to your project composer.json. If you have a folder called "dkan" in your project root, it will symlink to that as your dkan dependency rather than pulling from packagist.

## QA Steps

1. Create a new project dir ("localdkan")
2. `cd localdkan && git clone git@github.com:getdkan/dkan.git`
3. `dktl init --dkan-local`
4. `dktl make`

Confirm that when composer installs DKAN it outputs `Installing getdkan/dkan (2.x-dev): Symlinking from dkan` rather than `Downloading (100%)`

### or...

Just examine the test output of GetDKAN/dkan#3223

**Note:** This PR also slightly refactors the dktl bash script to better handle running from directories that contain spaces in their names.

Fixes GetDKAN/dkan#3193
