### PR TITLE
Ask confirmation before overriding composer.json

### DIFF
--- a/src/DrupalProjectTrait.php
+++ b/src/DrupalProjectTrait.php
@@ -43,6 +43,14 @@ trait DrupalProjectTrait
      */
     private function drupalProjectMoveComposerFiles()
     {
+        if (file_exists(Util::getProjectDirectory() . "/composer.json")) {
+            $override = $this->confirm('composer.json already exists, replace?');
+            if (!$override) {
+                $this->io()->warning('Skipping composer.json');
+                return;
+            }
+        }
+
         $moveFiles = $this->taskFilesystemStack()
             ->rename(
                 Util::TMP_DIR . "/composer.json",


### PR DESCRIPTION
Fixes: https://github.com/GetDKAN/dkan-tools/issues/259

On an existing dktl project. Running `dktl init` should ask before overriding the existing `composer.json` file. 