### PR TITLE
Fail the make command if composer exits with error

### DIFF
--- a/src/Command/MakeCommands.php
+++ b/src/Command/MakeCommands.php
@@ -53,7 +53,10 @@ class MakeCommands extends Tasks
                 $composerInstall->option($opt);
             }
         }
-        $composerInstall->run();
+        $result = $composerInstall->run();
+        if ($result->getExitCode() != 0) {
+            return $result;
+        }
 
         // Symlink dirs from src into docroot.
         $this->makeSymlinks();


### PR DESCRIPTION
Currently if composer fails (usually due to a constraint issue) during the make, this is not detected and the command continues and still exits successfully. Among other thigns this leads to confusing CI output and CI jobs continuing long after they should have quit. This will check for an exit code and fail if found.

See this demonstration: https://app.circleci.com/pipelines/github/GetDKAN/dkan/1078/workflows/28e1d40d-6a2a-4da9-ac8b-fe8ca932cd6c/jobs/13758