### PR TITLE
Revert "Remove a duplicate code line"

### DIFF
--- a/bin/dktl
+++ b/bin/dktl
@@ -134,6 +134,7 @@ set_directory() {
     DKTL_DIRECTORY=$(readlink $RL_OPT "$DKTL_DIRECTORY")
   fi
   DKTL_DIRECTORY=$(dirname "$DKTL_DIRECTORY")
+  DKTL_DIRECTORY=$(dirname "$DKTL_DIRECTORY")
   export DKTL_DIRECTORY
 }
 

--- a/bin/dktl
+++ b/bin/dktl
@@ -133,8 +133,11 @@ set_directory() {
     if [ "$PLATFORM" = "Linux" ]; then RL_OPT='-f'; fi;
     DKTL_DIRECTORY=$(readlink $RL_OPT "$DKTL_DIRECTORY")
   fi
-  DKTL_DIRECTORY=$(dirname "$DKTL_DIRECTORY")
-  DKTL_DIRECTORY=$(dirname "$DKTL_DIRECTORY")
+
+  # Currently DKTL_DIRECTORY contains <path/to/dktl/root>/bin/dktl, strip the
+  # /bin/dktl to get the root dktl directory.
+  DKTL_DIRECTORY="${DKTL_DIRECTORY%/bin/dktl}"
+
   export DKTL_DIRECTORY
 }
 

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -82,7 +82,7 @@ testDktlInstall() {
     result=`curl $url/user/login`
     assertContains "${result}" "Enter your DKAN username"
     result=`dktl install:sample`
-    assertContains "${result}" "Processed 33 items from the datastore_import"
+    assertContains "${result}" "Processed 30 items from the datastore_import"
 }
 
 testFrontEnd() {


### PR DESCRIPTION
Reverts GetDKAN/dkan-tools#273.

This was not a duplicate - perhaps code could be clearer but we need to move up two directories. `dirname` gives us the parent dir of the path we pass it.