### PR TITLE
Use new project and change some composer logic

### DIFF
--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -197,23 +197,19 @@ class InitCommands extends \Robo\Tasks
     /**
      * Create a new Drupal project in the current directory. If one exists, it
      * will be overwritten.
-     *
-     * @param mixed $drupalVersion
-     *   Drupal version to use, expressed as Composer constraint.
      */
-    public function initDrupal($drupalVersion)
+    public function initDrupal()
     {
         $this->io()->section('Creating new Drupal project.');
         Util::prepareTmp();
 
         // Composer's create-project requires an empty folder, so run it in
         // Util::Tmp, then move the 2 composer files back into project root.
-        $this->drupalProjectCreate($drupalVersion);
+        $this->drupalProjectCreate();
         $this->drupalProjectMoveComposerFiles();
 
         // Modify project's scaffold and installation paths to `docroot`, then
         // install Drupal in it.
-        $this->drupalProjectSetDocrootPath();
         if (!is_dir('docroot')) {
             $this->_mkdir('docroot');
         }

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -26,16 +26,11 @@ class InitCommands extends \Robo\Tasks
      *   If no version constraint is provided via the --dkan option, dktl will
      *   attempt to generate one based on the current git branch in "dkan".
     */
-    public function init($opts = ['drupal' => '9.0.0', 'dkan' => null, 'dkan-local' => false])
+    public function init($opts = ['dkan' => null, 'dkan-local' => false])
     {
-        // Validate version is semantic and at least the minimum set
-        // in DrupalProjectTrait.
-        if (!$this->drupalProjectValidateVersion($opts['drupal'])) {
-            exit;
-        }
         $this->initConfig();
         $this->initSrc();
-        $this->initDrupal($opts['drupal']);
+        $this->initDrupal();
         if ($opts['dkan-local']) {
             $this->initLocalDkan();
             $version = $this->localDkanVersion();

--- a/src/Command/MakeCommands.php
+++ b/src/Command/MakeCommands.php
@@ -38,16 +38,16 @@ class MakeCommands extends Tasks
      */
     public function make($opts = [
         'prefer-source' => false,
-        'prefer-dist' => false,
-        'no-dev' => false,
+        'prefer-dist' => true,
         'optimize-autoloader' => false,
+        'dev' => true,
     ])
     {
         $this->io()->section("Running dktl make");
 
         // Run composer install while passing the options.
         $composerInstall = $this->taskComposerInstall();
-        $composerOptions = ['prefer-source', 'prefer-dist', 'no-dev', 'optimize-autoloader'];
+        $composerOptions = ['prefer-source', 'prefer-dist', 'optimize-autoloader'];
         foreach ($composerOptions as $opt) {
             if ($opts[$opt]) {
                 $composerInstall->option($opt);

--- a/src/Command/MakeCommands.php
+++ b/src/Command/MakeCommands.php
@@ -47,7 +47,7 @@ class MakeCommands extends Tasks
 
         // Run composer install while passing the options.
         $composerInstall = $this->taskComposerInstall();
-        $composerOptions = ['prefer-source', 'prefer-dist', 'optimize-autoloader'];
+        $composerOptions = ['prefer-source', 'prefer-dist', 'optimize-autoloader', 'dev'];
         foreach ($composerOptions as $opt) {
             if ($opts[$opt]) {
                 $composerInstall->option($opt);

--- a/src/DrupalProjectTrait.php
+++ b/src/DrupalProjectTrait.php
@@ -24,12 +24,13 @@ trait DrupalProjectTrait
      */
     private static $drupalDocroot = 'docroot';
 
-    private function drupalProjectCreate(string $version)
+    private function drupalProjectCreate()
     {
-        $projectSource = "drupal/recommended-project:{$version}";
+        $projectSource = "getdkan/recommended-project:9.x-dev";
         $createFiles = $this->taskComposerCreateProject()
             ->source($projectSource)
             ->target(Util::TMP_DIR)
+            ->preferDist(true)
             ->noInstall()
             ->run();
         if ($createFiles->getExitCode() != 0) {
@@ -64,23 +65,6 @@ trait DrupalProjectTrait
             exit;
         }
         $this->io()->success('composer.json moved to project root.');
-    }
-
-    /**
-     * Rewrite composer.json with correct docroot.
-     */
-    private function drupalProjectSetDocrootPath()
-    {
-        $docroot = self::$drupalDocroot;
-        $regexps = "s#web/#" . $docroot . "/#g";
-        $installationPaths = $this->taskExec("sed -i -E '{$regexps}'")
-            ->arg('composer.json')
-            ->run();
-        if ($installationPaths->getExitCode() != 0) {
-            $this->io()->error('Unable to modify composer.json paths.');
-            exit;
-        }
-        $this->io()->success("Composer installation paths modified to {$docroot}.");
     }
 
     /**

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -31,18 +31,6 @@ testDktlInitWithBadParameter() {
     assertContains "${result}" "[ERROR] version format not semantic.";
 }
 
-testDktlInitDrupalVersionLessThanMinimum()
-{
-    result=`dktl init --drupal=8.7.1`;
-    assertContains "${result}" "[ERROR] drupal version below minimal required."
-}
-
-testDktlInitDrupalVersionMoreThanMaximum()
-{
-    result=`dktl init --drupal=77.7.7`
-    assertContains "${result}" "Could not find package drupal/recommended-project with version 77.7.7."
-}
-
 testDktlInit() {
     result=`dktl init`
     assertContains "${result}" 'Composer project created'

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -28,7 +28,7 @@ testUninitialized() {
 
 testDktlInitWithBadParameter() {
     result=`dktl init --dkan=foobar`
-    assertContains "${result}" "Could not parse version constraint fubar"
+    assertContains "${result}" "Could not parse version constraint foobar"
     rm -rf composer.* dktl.yml docrot src
 }
 

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -28,7 +28,8 @@ testUninitialized() {
 
 testDktlInitWithBadParameter() {
     result=`dktl init --drupal=foobar`
-    assertContains "${result}" "[ERROR] version format not semantic.";
+    assertContains "${result}" "Could not parse version constraint fubar"
+    rm -rf composer.* dktl.yml docrot src
 }
 
 testDktlInit() {

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -27,7 +27,7 @@ testUninitialized() {
 }
 
 testDktlInitWithBadParameter() {
-    result=`dktl init --drupal=foobar`
+    result=`dktl init --dkan=foobar`
     assertContains "${result}" "Could not parse version constraint fubar"
     rm -rf composer.* dktl.yml docrot src
 }

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -28,7 +28,7 @@ testUninitialized() {
 
 testDktlInitWithBadParameter() {
     result=`dktl init --dkan=foobar`
-    assertContains "${result}" "Could not parse version constraint foodktl bar"
+    assertContains "${result}" "Could not parse version constraint foobar"
     rm -rf composer.* dktl.yml docrot src
 }
 

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -28,7 +28,7 @@ testUninitialized() {
 
 testDktlInitWithBadParameter() {
     result=`dktl init --dkan=foobar`
-    assertContains "${result}" "Could not parse version constraint foobar"
+    assertContains "${result}" "Could not parse version constraint foodktl bar"
     rm -rf composer.* dktl.yml docrot src
 }
 
@@ -71,7 +71,7 @@ testDktlInstall() {
     result=`curl $url/user/login`
     assertContains "${result}" "Enter your DKAN username"
     result=`dktl install:sample`
-    assertContains "${result}" "Processed 30 items from the datastore_import"
+    assertContains "${result}" "Processed 10 items from the datastore_import"
 }
 
 testFrontEnd() {


### PR DESCRIPTION
Instead of using then overriding the default drupal recommended composer project, we're going to start using a new [DKAN recommended project](https://packagist.org/packages/getdkan/recommended-project#9.x-dev).