### PR TITLE
Use no-dev instead of dev with composer install.

### DIFF
--- a/src/Command/MakeCommands.php
+++ b/src/Command/MakeCommands.php
@@ -40,14 +40,14 @@ class MakeCommands extends Tasks
         'prefer-source' => false,
         'prefer-dist' => true,
         'optimize-autoloader' => false,
-        'dev' => true,
+        'no-dev' => false,
     ])
     {
         $this->io()->section("Running dktl make");
 
         // Run composer install while passing the options.
         $composerInstall = $this->taskComposerInstall();
-        $composerOptions = ['prefer-source', 'prefer-dist', 'optimize-autoloader', 'dev'];
+        $composerOptions = ['prefer-source', 'prefer-dist', 'optimize-autoloader', 'no-dev'];
         foreach ($composerOptions as $opt) {
             if ($opts[$opt]) {
                 $composerInstall->option($opt);


### PR DESCRIPTION
Every time we run dktl make we get a deprecation notice because we use the --dev option with composer install. This PR simply offers the same functionality using the --no-dev option which will not be deprecated.