### PR TITLE
Fix method for determining DKAN project directory

### DIFF
--- a/bin/dktl
+++ b/bin/dktl
@@ -112,11 +112,11 @@ set_project_directory() {
     echo "$path"
   }
 
-  DKTL_PROJECT_DIRECTORY=$(find_up dktl.yml)
-  if [ -z "$DKTL_PROJECT_DIRECTORY" ]; then
-    if [ "$1" = "init" ] || [ "$1" = "down" ]; then
-      DKTL_PROJECT_DIRECTORY=$(pwd)
-    else
+  if [ "$1" = "init" ] || [ "$1" = "down" ]; then
+    DKTL_PROJECT_DIRECTORY=$(pwd)
+  else
+    DKTL_PROJECT_DIRECTORY=$(find_up dktl.yml)
+    if [ -z "$DKTL_PROJECT_DIRECTORY" ]; then
       echo "DKTL is running outside of a DKTL project. Run dktl init in the project directory first."
       exit 1
     fi


### PR DESCRIPTION
### Problem
When running `dktl init` in a folder with only a vanilla dkan project instance, I received the following error:
```
No local dkan folder in project root.
```
### Solution
It seems the logic used to determine the location of the current DKAN project was incorrect. It expected a "dktl.yml" file to be present in the current directory, or in some parent directory. It then noticed I had a stray "dktl.yml" file in my home directory and thought my home directory was the project directory.
I've updated the project directory detection logic to assume that the current directory is the project directory when `dktl init` or `dktl make` is called.
### QA Instructions

1. Create a directory containing only an empty "dktl.yml" file.
2. Create a subdirectory within that directory.
3. In the subdirectory, clone a copy of DKAN core into a directory named "dkan".
4. In the subdirectory, run `dktl init --dkan-local` and make sure the command finished successfully and that you do not receive the error message:
```
No local dkan folder in project root.
```