### PR TITLE
Use cypress from the container

### DIFF
--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -42,7 +42,7 @@ services:
   # Used for all console commands and tools.
   cli:
     hostname: cli
-    image: getdkan/dkan-cli:v0.4.0
+    image: getdkan/dkan-cli:v0.4.1
     env_file:
       - "${DKTL_DIRECTORY}/assets/docker/mysql.env"
     environment:

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -3,6 +3,7 @@
 namespace DkanTools\Command;
 
 use DkanTools\Util\Util;
+use DkanTools\Util\TestUserTrait;
 
 /**
  * This is project's console commands configuration for Robo task runner.
@@ -12,6 +13,8 @@ use DkanTools\Util\Util;
  */
 class DkanCommands extends \Robo\Tasks
 {
+    use TestUserTrait;
+
     /**
      * Build DKAN docs with doxygen.
      */
@@ -30,8 +33,8 @@ class DkanCommands extends \Robo\Tasks
      */
     public function dkanTestCypress(array $args)
     {
-        $this->dkanTestUser("testuser", "2jqzOAnXS9mmcLasy", "api_user");
-        $this->dkanTestUser("testeditor", "testeditor", "administrator");
+        $this->apiUser();
+        $this->editorUser();
 
         $this->taskExec("npm install cypress")
             ->dir("docroot/modules/contrib/dkan")
@@ -207,12 +210,4 @@ class DkanCommands extends \Robo\Tasks
         $this->io()->success("Your dev site is available at: " . Util::getUri());
     }
 
-    private function dkanTestUser($name, $pass, $roll)
-    {
-        $this->taskExecStack()
-            ->stopOnFail()
-            ->exec("dktl drush user:create $name --password=$pass")
-            ->exec("dktl drush user-add-role $roll $name")
-            ->run();
-    }
 }

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -36,9 +36,9 @@ class DkanCommands extends \Robo\Tasks
         $this->apiUser();
         $this->editorUser();
 
-        $this->taskExec("npm install cypress")
-            ->dir("docroot/modules/contrib/dkan")
-            ->run();
+        // $this->taskExec("npm install cypress")
+        //     ->dir("docroot/modules/contrib/dkan")
+        //     ->run();
 
         $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
             ->dir("docroot/modules/contrib/dkan");

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -209,5 +209,4 @@ class DkanCommands extends \Robo\Tasks
 
         $this->io()->success("Your dev site is available at: " . Util::getUri());
     }
-
 }

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -210,9 +210,9 @@ class FrontendCommands extends Tasks
      */
     public function frontendTest()
     {
-        $this->taskExec("npm install cypress")
-        ->dir("docroot/frontend")
-        ->run();
+        // $this->taskExec("npm install cypress")
+        // ->dir("docroot/frontend")
+        // ->run();
 
         return $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
             ->dir("docroot/frontend")

--- a/src/Command/MakeCommands.php
+++ b/src/Command/MakeCommands.php
@@ -79,9 +79,9 @@ class MakeCommands extends Tasks
             ['target' => 'src/themes',  'link' => '/themes/custom'],
             ['target' => 'src/libraries',  'link' => '/libraries'],
             ['target' => 'src/schema',  'link' => '/schema'],
-	        ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/test/node_modules'],
-            ['target' => '../../usr/local/bin/node_modules',  'link' => '/../dkan/test/node_modules'],
-            ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/frontend/node_modules'],
+	    ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/test/node_modules'],
+	    ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/frontend/node_modules'],
+	    ['target' => '../../usr/local/bin/node_modules',  'link' => '/../dkan/test/node_modules'],
         ];
         foreach ($targetsAndLinks as $targetAndLink) {
             $this->docrootSymlink(

--- a/src/Command/MakeCommands.php
+++ b/src/Command/MakeCommands.php
@@ -79,6 +79,7 @@ class MakeCommands extends Tasks
             ['target' => 'src/themes',  'link' => '/themes/custom'],
             ['target' => 'src/libraries',  'link' => '/libraries'],
             ['target' => 'src/schema',  'link' => '/schema'],
+	    ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/test/node_modules'],
         ];
         foreach ($targetsAndLinks as $targetAndLink) {
             $this->docrootSymlink(

--- a/src/Command/MakeCommands.php
+++ b/src/Command/MakeCommands.php
@@ -79,7 +79,9 @@ class MakeCommands extends Tasks
             ['target' => 'src/themes',  'link' => '/themes/custom'],
             ['target' => 'src/libraries',  'link' => '/libraries'],
             ['target' => 'src/schema',  'link' => '/schema'],
-	    ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/test/node_modules'],
+	        ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/test/node_modules'],
+            ['target' => '../../usr/local/bin/node_modules',  'link' => '/../dkan/test/node_modules'],
+            ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/frontend/node_modules'],
         ];
         foreach ($targetsAndLinks as $targetAndLink) {
             $this->docrootSymlink(

--- a/src/Command/MakeCommands.php
+++ b/src/Command/MakeCommands.php
@@ -79,9 +79,9 @@ class MakeCommands extends Tasks
             ['target' => 'src/themes',  'link' => '/themes/custom'],
             ['target' => 'src/libraries',  'link' => '/libraries'],
             ['target' => 'src/schema',  'link' => '/schema'],
-	    ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/test/node_modules'],
-	    ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/frontend/node_modules'],
-	    ['target' => '../../usr/local/bin/node_modules',  'link' => '/../dkan/test/node_modules'],
+            ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/test/node_modules'],
+            ['target' => '../../usr/local/bin/node_modules',  'link' => '/../src/frontend/node_modules'],
+            ['target' => '../../usr/local/bin/node_modules',  'link' => '/../dkan/test/node_modules'],
         ];
         foreach ($targetsAndLinks as $targetAndLink) {
             $this->docrootSymlink(

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -3,6 +3,7 @@
 namespace DkanTools\Command;
 
 use DkanTools\Util\Util;
+use DkanTools\Util\TestUserTrait;
 
 /**
  * This project's console commands configuration for Robo task runner.
@@ -11,13 +12,15 @@ use DkanTools\Util\Util;
  */
 class ProjectCommands extends \Robo\Tasks
 {
+    use TestUserTrait;
+
     /**
      * Run project cypress tests.
      */
     public function projectTestCypress(array $args)
     {
-        $this->projectTestUser("testuser", "2jqzOAnXS9mmcLasy", "api_user");
-        $this->projectTestUser("testeditor", "testeditor", "administrator");
+        $this->apiUser();
+        $this->editorUser();
 
         $this->taskExec("npm install cypress")
             ->dir("src/test")
@@ -74,15 +77,5 @@ class ProjectCommands extends \Robo\Tasks
         $output = [];
         exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
         return (isset($output[0]) && $output[0] == 'HEAD');
-    }
-
-
-    private function projectTestUser($name, $pass, $roll)
-    {
-        $this->taskExecStack()
-            ->stopOnFail()
-            ->exec("dktl drush user:create $name --password=$pass")
-            ->exec("dktl drush user-add-role $roll $name")
-            ->run();
     }
 }

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DkanTools\Command;
+
+use DkanTools\Util\Util;
+
+/**
+ * This project's console commands configuration for Robo task runner.
+ *
+ * @see http://robo.li/
+ */
+class ProjectCommands extends \Robo\Tasks
+{
+    /**
+     * Run project cypress tests.
+     */
+    public function projectTestCypress(array $args)
+    {
+        $this->projectTestUser("testuser", "2jqzOAnXS9mmcLasy", "api_user");
+        $this->projectTestUser("testeditor", "testeditor", "administrator");
+
+        $this->taskExec("npm install cypress")
+            ->dir("src/test")
+            ->run();
+
+        $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
+            ->dir("src/test");
+
+        foreach ($args as $arg) {
+            $cypress->arg($arg);
+        }
+
+        return $cypress->run();
+    }
+
+    /**
+     * Run Site PhpUnit Tests. Additional phpunit CLI options can be passed.
+     *
+     * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
+     * @param array $args Arguments to append to phpunit command.
+     */
+    public function projectTestPhpunit(array $args)
+    {
+        $proj_dir = Util::getProjectDirectory();
+        $phpunit_executable = $this->getPhpUnitExecutable();
+
+        $phpunitExec = $this->taskExec($phpunit_executable)
+            ->option('testsuite', 'Custom Test Suite')
+            ->dir("{$proj_dir}/docroot/modules/custom");
+
+        foreach ($args as $arg) {
+            $phpunitExec->arg($arg);
+        }
+
+        return $phpunitExec->run();
+    }
+
+    private function getPhpUnitExecutable()
+    {
+        $proj_dir = Util::getProjectDirectory();
+
+        $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
+
+        if (!file_exists($phpunit_executable)) {
+            $this->taskExec("dktl installphpunit")->run();
+            $phpunit_executable = "phpunit";
+        }
+
+        return $phpunit_executable;
+    }
+
+    private function inGitDetachedState($dkanDirPath)
+    {
+        $output = [];
+        exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
+        return (isset($output[0]) && $output[0] == 'HEAD');
+    }
+
+
+    private function projectTestUser($name, $pass, $roll)
+    {
+        $this->taskExecStack()
+            ->stopOnFail()
+            ->exec("dktl drush user:create $name --password=$pass")
+            ->exec("dktl drush user-add-role $roll $name")
+            ->run();
+    }
+}

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -22,9 +22,9 @@ class ProjectCommands extends \Robo\Tasks
         $this->apiUser();
         $this->editorUser();
 
-        $this->taskExec("npm install cypress")
-            ->dir("src/test")
-            ->run();
+        //$this->taskExec("npm install cypress")
+        //    ->dir("src/test")
+        //    ->run();
 
         $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
             ->dir("src/test");

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DkanTools\Util;
+
+/**
+ * Test User Trait.
+ */
+trait TestUserTrait {
+
+  /**
+   * Private create user.
+   */
+  private function create($name, $pass, $roll) {
+    $this->taskExecStack()
+      ->stopOnFail()
+      ->exec("dktl drush user:create $name --password=$pass")
+      ->exec("dktl drush user-add-role $roll $name")
+      ->run();
+  }
+
+  /**
+   * Protected create api user.
+   */
+  protected function apiUser() {
+    $this->create("testuser", "2jqzOAnXS9mmcLasy", "api_user");
+  }
+
+  /**
+   * Protected create editor.
+   */
+  protected function editorUser() {
+    $this->create("testeditor", "D8Z3nXoifqspwZxo", "administrator");
+  }
+
+}

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -32,6 +32,6 @@ trait TestUserTrait
      */
     protected function editorUser()
     {
-        $this->create("testeditor", "D8Z3nXoifqspwZxo", "administrator");
+        $this->create("testeditor", "testeditor", "administrator");
     }
 }

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -5,31 +5,33 @@ namespace DkanTools\Util;
 /**
  * Test User Trait.
  */
-trait TestUserTrait {
+trait TestUserTrait
+{
+    /**
+     * Private create user.
+     */
+    private function create($name, $pass, $roll)
+    {
+        $this->taskExecStack()
+            ->stopOnFail()
+            ->exec("dktl drush user:create $name --password=$pass")
+            ->exec("dktl drush user-add-role $roll $name")
+            ->run();
+    }
 
-  /**
-   * Private create user.
-   */
-  private function create($name, $pass, $roll) {
-    $this->taskExecStack()
-      ->stopOnFail()
-      ->exec("dktl drush user:create $name --password=$pass")
-      ->exec("dktl drush user-add-role $roll $name")
-      ->run();
-  }
+    /**
+     * Protected create api user.
+     */
+    protected function apiUser()
+    {
+        $this->create("testuser", "2jqzOAnXS9mmcLasy", "api_user");
+    }
 
-  /**
-   * Protected create api user.
-   */
-  protected function apiUser() {
-    $this->create("testuser", "2jqzOAnXS9mmcLasy", "api_user");
-  }
-
-  /**
-   * Protected create editor.
-   */
-  protected function editorUser() {
-    $this->create("testeditor", "D8Z3nXoifqspwZxo", "administrator");
-  }
-
+    /**
+     * Protected create editor.
+     */
+    protected function editorUser()
+    {
+        $this->create("testeditor", "D8Z3nXoifqspwZxo", "administrator");
+    }
 }


### PR DESCRIPTION
@dasumner this still is installing cypress in src/test, can we talk about how to access it from the container and how we can add dependencies such as

{
  "devDependencies": {
    "@testing-library/cypress": "^6.0.0",
    "@testing-library/dom": "^7.16.1",
    "eslint-plugin-cypress": "^2.11.1"
  }
}

Also I changed the command to 'project' so

```
dktl project:test-cypress
dktl project:test-phpunit
```