### PR TITLE
Switch to drydock/percona database image

### DIFF
--- a/assets/docker/docker-compose.common.yml
+++ b/assets/docker/docker-compose.common.yml
@@ -28,15 +28,14 @@ services:
   # DB node
   db:
     hostname: db
-    image: wodby/mariadb:10.3-3.8.5
+    image: drydockcloud/drupal-acquia-mysql:latest
     ports:
       - "3306"
-    # MYSQL Credentials in mysql.env
     env_file:
       - "${DKTL_DIRECTORY}/assets/docker/mysql.env"
     volumes:
-       # MySQL configuration overrides
-       - "${DKTL_DIRECTORY}/assets/docker/etc/mysql/my.cnf:/etc/mysql/conf.d/z_my.cnf"
+       - "${DKTL_DIRECTORY}/assets/docker/etc/mysql/my.cnf:/etc/my.cnf"
+       - mysql_data:/var/lib/mysql
 
   # CLI node
   # Used for all console commands and tools.
@@ -73,3 +72,4 @@ services:
 
 volumes:
   composer:
+  mysql_data:

--- a/assets/docker/etc/mysql/my.cnf
+++ b/assets/docker/etc/mysql/my.cnf
@@ -1,8 +1,8 @@
+# Overrides to roughly simulate Acquia DB settings
+
 [mysqld]
-###############################
+
 local_infile=1
-# Acquia DD settings
-#set innodb as default
 default-storage-engine=InnoDB
 
 innodb_log_buffer_size=32M
@@ -11,12 +11,11 @@ innodb_log_file_size=32M
 
 innodb_file_per_table=1
 
-#Max packets
 max_allowed_packet = 128M
 
-#Enable slow query log
 long_query_time=1
 slow_query_log=1
 slow_query_log_file=slow.log
 
-###############################
+character-set-server=utf8
+collation-server=utf8_general_ci


### PR DESCRIPTION
We are using [drydock](https://github.com/drydockcloud/drupal-acquia) under the hood for our CLI image, so we should switch to using it for our database image as well. This will more closely emulate the acquia environment.