### PR TITLE
Adding ability to create test accounts using a file to the testing trait

### DIFF
--- a/docs/testusers.md
+++ b/docs/testusers.md
@@ -1,0 +1,29 @@
+# Test user accounts
+
+To create test user accounts when running tests, add a file to the root of your project called testUsers.json
+
+Add the accounts for each role you will be testing.
+
+```
+[
+  {
+    "name": "testapiuser",
+    "mail": "testapiuser@test.com",
+    "role": "api_user"
+  },
+  {
+    "name": "testadmin",
+    "mail": "testadmin@test.com",
+    "role": "administrator"
+  }
+]
+```
+
+When you run `dktl dkan:test-cypress` for core tests, or `dktl project:test-cypress` for project tests,
+the users will be generated, the tests will run, then then user accounts will be deleted.
+
+## Create Test Users
+To create the accounts without running tests, run `dktl dkan:qa-users-create` or `dktl qauc`.
+
+## Delete Test Users
+To delete the accounts, run `dktl dkan:qa-users-delete` or `dktl qaud`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
     - 'patching.md'
     - 'Custom commands': 'extend.md'
     - 'Modifying the Docker containers': 'docker_config.md'
+    - 'Test users': 'testusers.md'
     - 'troubleshooting.md'
 markdown_extensions:
     - admonition

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -30,16 +30,22 @@ class DkanCommands extends \Robo\Tasks
 
     /**
      * Create QA users.
+     *
+     * @command dkan:qa-users-create
+     * @aliases qauc
      */
-    public function dkanQaCreate()
+    public function dkanQaUsersCreate()
     {
         return $this->createTestUsers();
     }
 
     /**
      * Remove QA users.
+     *
+     * @command dkan:qa-users-delete
+     * @aliases qaud
      */
-    public function dkanQaRemove()
+    public function dkanQaUsersDelete()
     {
         return $this->deleteTestUsers();
     }

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -56,14 +56,15 @@ class DkanCommands extends \Robo\Tasks
      */
     public function dkanTestDredd()
     {
-        $this->apiUser();
+        $this->createTestUsers();
         $this->taskExec("npm install dredd")
             ->dir("docroot/modules/contrib/dkan")
             ->run();
 
-        return $this->taskExec("npx dredd --hookfiles=./dredd-hooks.js")
+        $this->taskExec("npx dredd --hookfiles=./dredd-hooks.js")
             ->dir("docroot/modules/contrib/dkan/dredd")
             ->run();
+        return $this->deleteTestUsers();
     }
 
     /**
@@ -74,7 +75,7 @@ class DkanCommands extends \Robo\Tasks
      */
     public function dkanTestPhpunit(array $args)
     {
-        $this->apiUser();
+        $this->createTestUsers();
         $proj_dir = Util::getProjectDirectory();
         $phpunit_executable = $this->getPhpUnitExecutable();
 
@@ -86,7 +87,8 @@ class DkanCommands extends \Robo\Tasks
             $phpunitExec->arg($arg);
         }
 
-        return $phpunitExec->run();
+        $phpunitExec->run();
+        return $this->deleteTestUsers();
     }
 
     /**
@@ -94,7 +96,7 @@ class DkanCommands extends \Robo\Tasks
      */
     public function dkanTestPhpunitCoverage($code_climate_reporter_id)
     {
-        $this->apiUser();
+        $this->createTestUsers();
         $proj_dir = Util::getProjectDirectory();
         $dkanDir = "{$proj_dir}/docroot/modules/contrib/dkan";
 
@@ -124,6 +126,7 @@ class DkanCommands extends \Robo\Tasks
             ->dir($dkanDir)
             ->silent(true)
             ->run();
+        $this->deleteTestUsers();
         return $result;
     }
 

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -13,237 +13,249 @@ use DkanTools\Util\TestUserTrait;
  *
  * @see http://robo.li/
  */
-class DkanCommands extends \Robo\Tasks {
-  use TestUserTrait;
+class DkanCommands extends \Robo\Tasks
+{
+    use TestUserTrait;
 
-  /**
-   * Build DKAN docs with doxygen.
-   */
-  public function dkanDocs() {
-    $proj_dir = Util::getProjectDirectory();
-    $this->taskExec("doxygen")
-      ->dir("{$proj_dir}/docroot/modules/contrib/dkan")
-      ->run();
-    $url = Util::getUri();
-    $this->io()->text("Docs site: $url/modules/contrib/dkan/docs/index.html");
-  }
-
-  /**
-   * Create QA users.
-   *
-   * @command dkan:qa-users-create
-   * @aliases qauc
-   */
-  public function dkanQaUsersCreate() {
-    return $this->createTestUsers();
-  }
-
-  /**
-   * Remove QA users.
-   *
-   * @command dkan:qa-users-delete
-   * @aliases qaud
-   */
-  public function dkanQaUsersDelete() {
-    return $this->deleteTestUsers();
-  }
-
-  /**
-   * Run DKAN Cypress Tests.
-   */
-  public function dkanTestCypress(array $args) {
-    $this->createTestUsers();
-
-    $this->taskExec("npm cache verify && npm install")
-      ->dir("docroot/modules/contrib/dkan")
-      ->run();
-
-    $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
-      ->dir("docroot/modules/contrib/dkan");
-
-    foreach ($args as $arg) {
-      $cypress->arg($arg);
+    /**
+     * Build DKAN docs with doxygen.
+     */
+    public function dkanDocs()
+    {
+        $proj_dir = Util::getProjectDirectory();
+        $this->taskExec("doxygen")
+            ->dir("{$proj_dir}/docroot/modules/contrib/dkan")
+            ->run();
+        $url = Util::getUri();
+        $this->io()->text("Docs site: $url/modules/contrib/dkan/docs/index.html");
     }
 
-    $cypress->run();
-    $this->deleteTestUsers();
-  }
-
-  /**
-   * Run DKAN Dredd Tests.
-   */
-  public function dkanTestDredd() {
-    $this->createTestUsers();
-    $this->taskExec("npm install dredd")
-      ->dir("docroot/modules/contrib/dkan")
-      ->run();
-
-    $this->taskExec("npx dredd --hookfiles=./dredd-hooks.js")
-      ->dir("docroot/modules/contrib/dkan/dredd")
-      ->run();
-    $this->deleteTestUsers();
-  }
-
-  /**
-   * Run DKAN PhpUnit Tests. Additional phpunit CLI options can be passed.
-   *
-   * @param array $args
-   *   Arguments to append to phpunit command.
-   *
-   * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
-   */
-  public function dkanTestPhpunit(array $args) {
-    $this->createTestUsers();
-    $proj_dir = Util::getProjectDirectory();
-    $phpunit_executable = $this->getPhpUnitExecutable();
-
-    $phpunitExec = $this->taskExec($phpunit_executable)
-      ->option('testsuite', 'DKAN Test Suite')
-      ->dir("{$proj_dir}/docroot/modules/contrib/dkan");
-
-    foreach ($args as $arg) {
-      $phpunitExec->arg($arg);
+    /**
+     * Create QA users.
+     *
+     * @command dkan:qa-users-create
+     * @aliases qauc
+     */
+    public function dkanQaUsersCreate()
+    {
+        return $this->createTestUsers();
     }
 
-    $phpunitExec->run();
-    $this->deleteTestUsers();
-  }
-
-  /**
-   * Run DKAN PhpUnit Tests and send a coverage report to CodeClimate.
-   */
-  public function dkanTestPhpunitCoverage($code_climate_reporter_id) {
-    $this->createTestUsers();
-    $proj_dir = Util::getProjectDirectory();
-    $dkanDir = "{$proj_dir}/docroot/modules/contrib/dkan";
-
-    // Due to particularities of Composer, when we asked for the 2.x branch, we get a detached HEAD state.
-    // Code Climate's test reporter gets information from git. If we recognized a detached HEAD state, lets
-    // checkout our master branch: 2.x.
-    if ($this->inGitDetachedState($dkanDir)) {
-      exec("cd {$dkanDir} && git checkout 2.x");
+    /**
+     * Remove QA users.
+     *
+     * @command dkan:qa-users-delete
+     * @aliases qaud
+     */
+    public function dkanQaUsersDelete()
+    {
+        return $this->deleteTestUsers();
     }
 
-    $this->installCodeClimateTestReporter($dkanDir);
+    /**
+     * Run DKAN Cypress Tests.
+     */
+    public function dkanTestCypress(array $args)
+    {
+        $this->createTestUsers();
 
-    $phpunit_executable = $this->getPhpUnitExecutable();
+        $this->taskExec("npm cache verify && npm install")
+            ->dir("docroot/modules/contrib/dkan")
+            ->run();
 
-    $this->taskExec("./cc-test-reporter before-build")->dir($dkanDir)->run();
+        $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
+            ->dir("docroot/modules/contrib/dkan");
 
-    $phpunitExec = $this->taskExec($phpunit_executable)
-      ->option('testsuite', 'DKAN Test Suite')
-      ->option('coverage-clover', 'clover.xml')
-      ->dir($dkanDir);
+        foreach ($args as $arg) {
+            $cypress->arg($arg);
+        }
 
-    $result = $phpunitExec->run();
-
-    $this->taskExec(
-      "./cc-test-reporter after-build -r {$code_climate_reporter_id} --coverage-input-type clover --exit-code $?"
-    )
-      ->dir($dkanDir)
-      ->silent(TRUE)
-      ->run();
-    $this->deleteTestUsers();
-    return $result;
-  }
-
-  /**
-   * Include CodeClimate report.
-   */
-  private function installCodeClimateTestReporter($dkanDir) {
-    if (!file_exists("{$dkanDir}/cc-test-reporter")) {
-      $this->taskExec(
-        "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > "
-          . "./cc-test-reporter"
-      )
-        ->dir($dkanDir)->run();
-      $this->taskExec("chmod +x ./cc-test-reporter")->dir($dkanDir)->run();
-    }
-  }
-
-  /**
-   * Determine path to PHPUnit executable.
-   *
-   * @return string
-   */
-  private function getPhpUnitExecutable() {
-    $proj_dir = Util::getProjectDirectory();
-
-    $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
-
-    if (!file_exists($phpunit_executable)) {
-      $this->taskExec("dktl installphpunit")->run();
-      $phpunit_executable = "phpunit";
+        $cypress->run();
+        $this->deleteTestUsers();
     }
 
-    return $phpunit_executable;
-  }
+    /**
+     * Run DKAN Dredd Tests.
+     */
+    public function dkanTestDredd()
+    {
+        $this->createTestUsers();
+        $this->taskExec("npm install dredd")
+            ->dir("docroot/modules/contrib/dkan")
+            ->run();
 
-  /**
-   * Ensure current git branch is not in a detached state.
-   *
-   * @return bool
-   *   Flag for whether the current branch branch is detached.
-   */
-  private function inGitDetachedState($dkanDirPath) {
-    $output = [];
-    exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
-    return (isset($output[0]) && $output[0] == 'HEAD');
-  }
+        $this->taskExec("npx dredd --hookfiles=./dredd-hooks.js")
+            ->dir("docroot/modules/contrib/dkan/dredd")
+            ->run();
+        $this->deleteTestUsers();
+    }
 
-  /**
-   * Create a new demo project.
-   *
-   * Will have frontend and sample content. Run this immediately after dktl
-   * init.
-   *
-   * @aliases demo
-   */
-  public function dkanDemo() {
-    $this->taskExecStack()
-      ->stopOnFail()
-      ->exec("dktl make")
-      ->exec("dktl install")
-      ->exec("dktl install:sample")
-      ->exec("git clone -b "
-        . FrontendCommands::FRONTEND_VCS_REF
-        . " "
-        . FrontendCommands::FRONTEND_VCS_URL
-        . " " . FrontendCommands::FRONTEND_DIR)
-      ->exec("dktl frontend:install")
-      ->exec("dktl frontend:build")
-      ->exec("dktl drush cr")
-      ->run();
+    /**
+     * Run DKAN PhpUnit Tests. Additional phpunit CLI options can be passed.
+     *
+     * @param array $args
+     *   Arguments to append to phpunit command.
+     *
+     * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
+     */
+    public function dkanTestPhpunit(array $args)
+    {
+        $this->createTestUsers();
+        $proj_dir = Util::getProjectDirectory();
+        $phpunit_executable = $this->getPhpUnitExecutable();
 
-    $this->io()->success("Your demo site is available at: " . Util::getUri());
-  }
+        $phpunitExec = $this->taskExec($phpunit_executable)
+            ->option('testsuite', 'DKAN Test Suite')
+            ->dir("{$proj_dir}/docroot/modules/contrib/dkan");
 
-  /**
-   * Create a new dev project.
-   *
-   * Will have frontend and sample content. Run this immediately after dktl
-   * init.
-   *
-   * @aliases dev
-   */
-  public function dkanDev() {
-    $this->taskExecStack()
-      ->stopOnFail()
-      ->exec("dktl make --prefer-source")
-      ->exec("dktl install")
-      ->exec("dktl install:sample")
-      ->exec("git clone -b "
-        . FrontendCommands::FRONTEND_VCS_REF
-        . " "
-        . FrontendCommands::FRONTEND_VCS_URL
-        . " " . FrontendCommands::FRONTEND_DIR)
-      ->exec("dktl frontend:install")
-      ->exec("dktl frontend:build")
-      ->exec("dktl drush user:password admin admin")
-      ->exec("dktl drush cr")
-      ->run();
+        foreach ($args as $arg) {
+            $phpunitExec->arg($arg);
+        }
 
-    $this->io()->success("Your dev site is available at: " . Util::getUri());
-  }
+        $phpunitExec->run();
+        $this->deleteTestUsers();
+    }
 
+    /**
+     * Run DKAN PhpUnit Tests and send a coverage report to CodeClimate.
+     */
+    public function dkanTestPhpunitCoverage($code_climate_reporter_id)
+    {
+        $this->createTestUsers();
+        $proj_dir = Util::getProjectDirectory();
+        $dkanDir = "{$proj_dir}/docroot/modules/contrib/dkan";
+
+        // Due to particularities of Composer, when we asked for the 2.x branch, we get a detached HEAD state.
+        // Code Climate's test reporter gets information from git. If we recognized a detached HEAD state, lets
+        // checkout our master branch: 2.x.
+        if ($this->inGitDetachedState($dkanDir)) {
+            exec("cd {$dkanDir} && git checkout 2.x");
+        }
+
+        $this->installCodeClimateTestReporter($dkanDir);
+
+        $phpunit_executable = $this->getPhpUnitExecutable();
+
+        $this->taskExec("./cc-test-reporter before-build")->dir($dkanDir)->run();
+
+        $phpunitExec = $this->taskExec($phpunit_executable)
+            ->option('testsuite', 'DKAN Test Suite')
+            ->option('coverage-clover', 'clover.xml')
+            ->dir($dkanDir);
+
+        $result = $phpunitExec->run();
+
+        $this->taskExec(
+            "./cc-test-reporter after-build -r {$code_climate_reporter_id} --coverage-input-type clover --exit-code $?"
+        )
+            ->dir($dkanDir)
+            ->silent(TRUE)
+            ->run();
+        $this->deleteTestUsers();
+        return $result;
+    }
+
+    /**
+     * Include CodeClimate report.
+     */
+    private function installCodeClimateTestReporter($dkanDir)
+    {
+        if (!file_exists("{$dkanDir}/cc-test-reporter")) {
+            $this->taskExec(
+                "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > "
+                    . "./cc-test-reporter"
+            )
+                ->dir($dkanDir)->run();
+            $this->taskExec("chmod +x ./cc-test-reporter")->dir($dkanDir)->run();
+        }
+    }
+
+    /**
+     * Determine path to PHPUnit executable.
+     *
+     * @return string
+     */
+    private function getPhpUnitExecutable()
+    {
+        $proj_dir = Util::getProjectDirectory();
+
+        $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
+
+        if (!file_exists($phpunit_executable)) {
+            $this->taskExec("dktl installphpunit")->run();
+            $phpunit_executable = "phpunit";
+        }
+
+        return $phpunit_executable;
+    }
+
+    /**
+     * Ensure current git branch is not in a detached state.
+     *
+     * @return bool
+     *   Flag for whether the current branch branch is detached.
+     */
+    private function inGitDetachedState($dkanDirPath)
+    {
+        $output = [];
+        exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
+        return (isset($output[0]) && $output[0] == 'HEAD');
+    }
+
+    /**
+     * Create a new demo project.
+     *
+     * Will have frontend and sample content. Run this immediately after dktl
+     * init.
+     *
+     * @aliases demo
+     */
+    public function dkanDemo()
+    {
+        $this->taskExecStack()
+            ->stopOnFail()
+            ->exec("dktl make")
+            ->exec("dktl install")
+            ->exec("dktl install:sample")
+            ->exec("git clone -b "
+                . FrontendCommands::FRONTEND_VCS_REF
+                . " "
+                . FrontendCommands::FRONTEND_VCS_URL
+                . " " . FrontendCommands::FRONTEND_DIR)
+            ->exec("dktl frontend:install")
+            ->exec("dktl frontend:build")
+            ->exec("dktl drush cr")
+            ->run();
+
+        $this->io()->success("Your demo site is available at: " . Util::getUri());
+    }
+
+    /**
+     * Create a new dev project.
+     *
+     * Will have frontend and sample content. Run this immediately after dktl
+     * init.
+     *
+     * @aliases dev
+     */
+    public function dkanDev()
+    {
+        $this->taskExecStack()
+            ->stopOnFail()
+            ->exec("dktl make --prefer-source")
+            ->exec("dktl install")
+            ->exec("dktl install:sample")
+            ->exec("git clone -b "
+                . FrontendCommands::FRONTEND_VCS_REF
+                . " "
+                . FrontendCommands::FRONTEND_VCS_URL
+                . " " . FrontendCommands::FRONTEND_DIR)
+            ->exec("dktl frontend:install")
+            ->exec("dktl frontend:build")
+            ->exec("dktl drush user:password admin admin")
+            ->exec("dktl drush cr")
+            ->run();
+
+        $this->io()->success("Your dev site is available at: " . Util::getUri());
+    }
 }

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -149,7 +149,7 @@ class DkanCommands extends \Robo\Tasks
             "./cc-test-reporter after-build -r {$code_climate_reporter_id} --coverage-input-type clover --exit-code $?"
         )
             ->dir($dkanDir)
-            ->silent(TRUE)
+            ->silent(true)
             ->run();
         $this->deleteTestUsers();
         return $result;

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -8,237 +8,242 @@ use DkanTools\Util\TestUserTrait;
 /**
  * This is project's console commands configuration for Robo task runner.
  *
+ * @param $arg
+ *   use 'frontend' to run frontend cypress tests.
+ *
  * @see http://robo.li/
- * @param $arg use 'frontend' to run frontend cypress tests.
  */
-class DkanCommands extends \Robo\Tasks
-{
-    use TestUserTrait;
+class DkanCommands extends \Robo\Tasks {
+  use TestUserTrait;
 
-    /**
-     * Build DKAN docs with doxygen.
-     */
-    public function dkanDocs()
-    {
-        $proj_dir = Util::getProjectDirectory();
-        $this->taskExec("doxygen")
-            ->dir("{$proj_dir}/docroot/modules/contrib/dkan")
-            ->run();
-        $url = Util::getUri();
-        $this->io()->text("Docs site: $url/modules/contrib/dkan/docs/index.html");
+  /**
+   * Build DKAN docs with doxygen.
+   */
+  public function dkanDocs() {
+    $proj_dir = Util::getProjectDirectory();
+    $this->taskExec("doxygen")
+      ->dir("{$proj_dir}/docroot/modules/contrib/dkan")
+      ->run();
+    $url = Util::getUri();
+    $this->io()->text("Docs site: $url/modules/contrib/dkan/docs/index.html");
+  }
+
+  /**
+   * Create QA users.
+   *
+   * @command dkan:qa-users-create
+   * @aliases qauc
+   */
+  public function dkanQaUsersCreate() {
+    return $this->createTestUsers();
+  }
+
+  /**
+   * Remove QA users.
+   *
+   * @command dkan:qa-users-delete
+   * @aliases qaud
+   */
+  public function dkanQaUsersDelete() {
+    return $this->deleteTestUsers();
+  }
+
+  /**
+   * Run DKAN Cypress Tests.
+   */
+  public function dkanTestCypress(array $args) {
+    $this->createTestUsers();
+
+    $this->taskExec("npm cache verify && npm install")
+      ->dir("docroot/modules/contrib/dkan")
+      ->run();
+
+    $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
+      ->dir("docroot/modules/contrib/dkan");
+
+    foreach ($args as $arg) {
+      $cypress->arg($arg);
     }
 
-    /**
-     * Create QA users.
-     *
-     * @command dkan:qa-users-create
-     * @aliases qauc
-     */
-    public function dkanQaUsersCreate()
-    {
-        return $this->createTestUsers();
+    $cypress->run();
+    $this->deleteTestUsers();
+  }
+
+  /**
+   * Run DKAN Dredd Tests.
+   */
+  public function dkanTestDredd() {
+    $this->createTestUsers();
+    $this->taskExec("npm install dredd")
+      ->dir("docroot/modules/contrib/dkan")
+      ->run();
+
+    $this->taskExec("npx dredd --hookfiles=./dredd-hooks.js")
+      ->dir("docroot/modules/contrib/dkan/dredd")
+      ->run();
+    $this->deleteTestUsers();
+  }
+
+  /**
+   * Run DKAN PhpUnit Tests. Additional phpunit CLI options can be passed.
+   *
+   * @param array $args
+   *   Arguments to append to phpunit command.
+   *
+   * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
+   */
+  public function dkanTestPhpunit(array $args) {
+    $this->createTestUsers();
+    $proj_dir = Util::getProjectDirectory();
+    $phpunit_executable = $this->getPhpUnitExecutable();
+
+    $phpunitExec = $this->taskExec($phpunit_executable)
+      ->option('testsuite', 'DKAN Test Suite')
+      ->dir("{$proj_dir}/docroot/modules/contrib/dkan");
+
+    foreach ($args as $arg) {
+      $phpunitExec->arg($arg);
     }
 
-    /**
-     * Remove QA users.
-     *
-     * @command dkan:qa-users-delete
-     * @aliases qaud
-     */
-    public function dkanQaUsersDelete()
-    {
-        return $this->deleteTestUsers();
+    $phpunitExec->run();
+    $this->deleteTestUsers();
+  }
+
+  /**
+   * Run DKAN PhpUnit Tests and send a coverage report to CodeClimate.
+   */
+  public function dkanTestPhpunitCoverage($code_climate_reporter_id) {
+    $this->createTestUsers();
+    $proj_dir = Util::getProjectDirectory();
+    $dkanDir = "{$proj_dir}/docroot/modules/contrib/dkan";
+
+    // Due to particularities of Composer, when we asked for the 2.x branch, we get a detached HEAD state.
+    // Code Climate's test reporter gets information from git. If we recognized a detached HEAD state, lets
+    // checkout our master branch: 2.x.
+    if ($this->inGitDetachedState($dkanDir)) {
+      exec("cd {$dkanDir} && git checkout 2.x");
     }
 
-    /**
-     * Run DKAN Cypress Tests.
-     */
-    public function dkanTestCypress(array $args)
-    {
-        $this->createTestUsers();
+    $this->installCodeClimateTestReporter($dkanDir);
 
-        $this->taskExec("npm cache verify && npm install")
-          ->dir("docroot/modules/contrib/dkan")
-          ->run();
+    $phpunit_executable = $this->getPhpUnitExecutable();
 
-        $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
-            ->dir("docroot/modules/contrib/dkan");
+    $this->taskExec("./cc-test-reporter before-build")->dir($dkanDir)->run();
 
-        foreach ($args as $arg) {
-          $cypress->arg($arg);
-        }
+    $phpunitExec = $this->taskExec($phpunit_executable)
+      ->option('testsuite', 'DKAN Test Suite')
+      ->option('coverage-clover', 'clover.xml')
+      ->dir($dkanDir);
 
-        $cypress->run();
-        return $this->deleteTestUsers();
+    $result = $phpunitExec->run();
+
+    $this->taskExec(
+      "./cc-test-reporter after-build -r {$code_climate_reporter_id} --coverage-input-type clover --exit-code $?"
+    )
+      ->dir($dkanDir)
+      ->silent(TRUE)
+      ->run();
+    $this->deleteTestUsers();
+    return $result;
+  }
+
+  /**
+   * Include CodeClimate report.
+   */
+  private function installCodeClimateTestReporter($dkanDir) {
+    if (!file_exists("{$dkanDir}/cc-test-reporter")) {
+      $this->taskExec(
+        "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > "
+          . "./cc-test-reporter"
+      )
+        ->dir($dkanDir)->run();
+      $this->taskExec("chmod +x ./cc-test-reporter")->dir($dkanDir)->run();
+    }
+  }
+
+  /**
+   * Determine path to PHPUnit executable.
+   *
+   * @return string
+   */
+  private function getPhpUnitExecutable() {
+    $proj_dir = Util::getProjectDirectory();
+
+    $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
+
+    if (!file_exists($phpunit_executable)) {
+      $this->taskExec("dktl installphpunit")->run();
+      $phpunit_executable = "phpunit";
     }
 
-    /**
-     * Run DKAN Dredd Tests.
-     */
-    public function dkanTestDredd()
-    {
-        $this->createTestUsers();
-        $this->taskExec("npm install dredd")
-            ->dir("docroot/modules/contrib/dkan")
-            ->run();
+    return $phpunit_executable;
+  }
 
-        $this->taskExec("npx dredd --hookfiles=./dredd-hooks.js")
-            ->dir("docroot/modules/contrib/dkan/dredd")
-            ->run();
-        return $this->deleteTestUsers();
-    }
+  /**
+   * Ensure current git branch is not in a detached state.
+   *
+   * @return bool
+   *   Flag for whether the current branch branch is detached.
+   */
+  private function inGitDetachedState($dkanDirPath) {
+    $output = [];
+    exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
+    return (isset($output[0]) && $output[0] == 'HEAD');
+  }
 
-    /**
-     * Run DKAN PhpUnit Tests. Additional phpunit CLI options can be passed.
-     *
-     * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
-     * @param array $args Arguments to append to phpunit command.
-     */
-    public function dkanTestPhpunit(array $args)
-    {
-        $this->createTestUsers();
-        $proj_dir = Util::getProjectDirectory();
-        $phpunit_executable = $this->getPhpUnitExecutable();
+  /**
+   * Create a new demo project.
+   *
+   * Will have frontend and sample content. Run this immediately after dktl
+   * init.
+   *
+   * @aliases demo
+   */
+  public function dkanDemo() {
+    $this->taskExecStack()
+      ->stopOnFail()
+      ->exec("dktl make")
+      ->exec("dktl install")
+      ->exec("dktl install:sample")
+      ->exec("git clone -b "
+        . FrontendCommands::FRONTEND_VCS_REF
+        . " "
+        . FrontendCommands::FRONTEND_VCS_URL
+        . " " . FrontendCommands::FRONTEND_DIR)
+      ->exec("dktl frontend:install")
+      ->exec("dktl frontend:build")
+      ->exec("dktl drush cr")
+      ->run();
 
-        $phpunitExec = $this->taskExec($phpunit_executable)
-            ->option('testsuite', 'DKAN Test Suite')
-            ->dir("{$proj_dir}/docroot/modules/contrib/dkan");
+    $this->io()->success("Your demo site is available at: " . Util::getUri());
+  }
 
-        foreach ($args as $arg) {
-            $phpunitExec->arg($arg);
-        }
+  /**
+   * Create a new dev project.
+   *
+   * Will have frontend and sample content. Run this immediately after dktl
+   * init.
+   *
+   * @aliases dev
+   */
+  public function dkanDev() {
+    $this->taskExecStack()
+      ->stopOnFail()
+      ->exec("dktl make --prefer-source")
+      ->exec("dktl install")
+      ->exec("dktl install:sample")
+      ->exec("git clone -b "
+        . FrontendCommands::FRONTEND_VCS_REF
+        . " "
+        . FrontendCommands::FRONTEND_VCS_URL
+        . " " . FrontendCommands::FRONTEND_DIR)
+      ->exec("dktl frontend:install")
+      ->exec("dktl frontend:build")
+      ->exec("dktl drush user:password admin admin")
+      ->exec("dktl drush cr")
+      ->run();
 
-        $phpunitExec->run();
-        return $this->deleteTestUsers();
-    }
+    $this->io()->success("Your dev site is available at: " . Util::getUri());
+  }
 
-    /**
-     * Run DKAN PhpUnit Tests and send a coverage report to CodeClimate.
-     */
-    public function dkanTestPhpunitCoverage($code_climate_reporter_id)
-    {
-        $this->createTestUsers();
-        $proj_dir = Util::getProjectDirectory();
-        $dkanDir = "{$proj_dir}/docroot/modules/contrib/dkan";
-
-        // Due to particularities of Composer, when we asked for the 2.x branch, we get a detached HEAD state.
-        // Code Climate's test reporter gets information from git. If we recognized a detached HEAD state, lets
-        // checkout our master branch: 2.x.
-        if ($this->inGitDetachedState($dkanDir)) {
-            exec("cd {$dkanDir} && git checkout 2.x");
-        }
-
-        $this->installCodeClimateTestReporter($dkanDir);
-
-        $phpunit_executable = $this->getPhpUnitExecutable();
-
-        $this->taskExec("./cc-test-reporter before-build")->dir($dkanDir)->run();
-
-        $phpunitExec = $this->taskExec($phpunit_executable)
-            ->option('testsuite', 'DKAN Test Suite')
-            ->option('coverage-clover', 'clover.xml')
-            ->dir($dkanDir);
-
-        $result = $phpunitExec->run();
-
-        $this->taskExec(
-            "./cc-test-reporter after-build -r {$code_climate_reporter_id} --coverage-input-type clover --exit-code $?"
-        )
-            ->dir($dkanDir)
-            ->silent(true)
-            ->run();
-        $this->deleteTestUsers();
-        return $result;
-    }
-
-    private function installCodeClimateTestReporter($dkanDir)
-    {
-        if (!file_exists("{$dkanDir}/cc-test-reporter")) {
-            $this->taskExec(
-                "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > "
-                . "./cc-test-reporter"
-            )
-                ->dir($dkanDir)->run();
-            $this->taskExec("chmod +x ./cc-test-reporter")->dir($dkanDir)->run();
-        }
-    }
-
-    private function getPhpUnitExecutable()
-    {
-        $proj_dir = Util::getProjectDirectory();
-
-        $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
-
-        if (!file_exists($phpunit_executable)) {
-            $this->taskExec("dktl installphpunit")->run();
-            $phpunit_executable = "phpunit";
-        }
-
-        return $phpunit_executable;
-    }
-
-    private function inGitDetachedState($dkanDirPath)
-    {
-        $output = [];
-        exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
-        return (isset($output[0]) && $output[0] == 'HEAD');
-    }
-
-
-    /**
-     * Create a new demo project.
-     *
-     * Will have frontend and sample content. Run this immediately after dktl
-     * init.
-     *
-     * @aliases demo
-     */
-    public function dkanDemo()
-    {
-        $this->taskExecStack()
-            ->stopOnFail()
-            ->exec("dktl make")
-            ->exec("dktl install")
-            ->exec("dktl install:sample")
-            ->exec("git clone -b "
-                . FrontendCommands::FRONTEND_VCS_REF
-                . " "
-                . FrontendCommands::FRONTEND_VCS_URL
-                . " " . FrontendCommands::FRONTEND_DIR)
-            ->exec("dktl frontend:install")
-            ->exec("dktl frontend:build")
-            ->exec("dktl drush cr")
-            ->run();
-
-        $this->io()->success("Your demo site is available at: " . Util::getUri());
-    }
-
-    /**
-     * Create a new dev project.
-     *
-     * Will have frontend and sample content. Run this immediately after dktl
-     * init.
-     *
-     * @aliases dev
-     */
-    public function dkanDev()
-    {
-        $this->taskExecStack()
-            ->stopOnFail()
-            ->exec("dktl make --prefer-source")
-            ->exec("dktl install")
-            ->exec("dktl install:sample")
-            ->exec("git clone -b "
-                . FrontendCommands::FRONTEND_VCS_REF
-                . " "
-                . FrontendCommands::FRONTEND_VCS_URL
-                . " " . FrontendCommands::FRONTEND_DIR)
-            ->exec("dktl frontend:install")
-            ->exec("dktl frontend:build")
-            ->exec("dktl drush user:password admin admin")
-            ->exec("dktl drush cr")
-            ->run();
-
-        $this->io()->success("Your dev site is available at: " . Util::getUri());
-    }
 }

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -57,7 +57,7 @@ class DkanCommands extends \Robo\Tasks
     {
         $this->createTestUsers();
 
-        $this->taskExec("npm cache verify && cypress install")
+        $this->taskExec("npm cache verify && npm install")
           ->dir("docroot/modules/contrib/dkan")
           ->run();
 

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -29,6 +29,22 @@ class DkanCommands extends \Robo\Tasks
     }
 
     /**
+     * Create QA users.
+     */
+    public function dkanQaCreate()
+    {
+        return $this->createTestUsers();
+    }
+
+    /**
+     * Remove QA users.
+     */
+    public function dkanQaRemove()
+    {
+        return $this->deleteTestUsers();
+    }
+
+    /**
      * Run DKAN Cypress Tests.
      */
     public function dkanTestCypress(array $args)
@@ -36,7 +52,6 @@ class DkanCommands extends \Robo\Tasks
         $this->createTestUsers();
 
         $this->taskExec("npm cache verify && cypress install")
-        //$this->taskExec("npm cache clean --force && npm cache verify && npm install")
           ->dir("docroot/modules/contrib/dkan")
           ->run();
 

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -33,8 +33,12 @@ class DkanCommands extends \Robo\Tasks
      */
     public function dkanTestCypress(array $args)
     {
-        $this->apiUser();
-        $this->editorUser();
+        $this->createTestUsers();
+
+        $this->taskExec("npm cache verify && cypress install")
+        //$this->taskExec("npm cache clean --force && npm cache verify && npm install")
+          ->dir("docroot/modules/contrib/dkan")
+          ->run();
 
         $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
             ->dir("docroot/modules/contrib/dkan");
@@ -43,7 +47,8 @@ class DkanCommands extends \Robo\Tasks
           $cypress->arg($arg);
         }
 
-        return $cypress->run();
+        $cypress->run();
+        return $this->deleteTestUsers();
     }
 
     /**

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -47,7 +47,8 @@ class ProjectCommands extends \Robo\Tasks
             $cypress->arg($arg);
         }
 
-        return $cypress->run();
+        $cypress->run();
+        return $this->deleteTestUsers();
     }
 
     /**

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -10,99 +10,102 @@ use DkanTools\Util\TestUserTrait;
  *
  * @see http://robo.li/
  */
-class ProjectCommands extends Tasks {
-  use TestUserTrait;
+class ProjectCommands extends Tasks
+{
+    use TestUserTrait;
 
-  /**
-   * Run project cypress tests.
-   */
-  public function projectTestCypress(array $args) {
+    /**
+     * Run project cypress tests.
+     */
+    public function projectTestCypress(array $args)
+    {
 
-    $this->createTestUsers();
+        $this->createTestUsers();
 
-    $result = $this->taskExec("npm link ../../../../usr/local/bin/node_modules/cypress")
-      ->dir("src/frontend")
-      ->run();
-    if ($result && $result->getExitCode() === 0) {
-      $this->io()->success(
-        'Successfully symlinked global cypress into frontend folder.'
-      );
-    }
-    else {
-      $this->io()->error('Could not symlink package folder');
-      return $result;
-    }
+        $result = $this->taskExec("npm link ../../../../usr/local/bin/node_modules/cypress")
+            ->dir("src/frontend")
+            ->run();
+        if ($result && $result->getExitCode() === 0) {
+            $this->io()->success(
+                'Successfully symlinked global cypress into frontend folder.'
+            );
+        } else {
+            $this->io()->error('Could not symlink package folder');
+            return $result;
+        }
 
-    $task = $this
-      ->taskExec('npm install --force')
-      ->dir("src/tests");
-    $result = $task->run();
-    if ($result->getExitCode() != 0) {
-      $this->io()->error('Could not insall test dependencies.');
-      return $result;
-    }
-    $this->io()->success('Installation of test dependencies successful.');
-    $config = file_exists("src/tests/cypress.json") ? ' --config-file src/tests/cypress.json' : '';
-    $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run' . $config)
-      ->dir("src/tests");
+        $task = $this
+            ->taskExec('npm install --force')
+            ->dir("src/tests");
+        $result = $task->run();
+        if ($result->getExitCode() != 0) {
+            $this->io()->error('Could not insall test dependencies.');
+            return $result;
+        }
+        $this->io()->success('Installation of test dependencies successful.');
+        $config = file_exists("src/tests/cypress.json") ? ' --config-file src/tests/cypress.json' : '';
+        $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run' . $config)
+            ->dir("src/tests");
 
-    foreach ($args as $arg) {
-      $cypress->arg($arg);
-    }
+        foreach ($args as $arg) {
+            $cypress->arg($arg);
+        }
 
-    $cypress->run();
-    return $this->deleteTestUsers();
-  }
-
-  /**
-   * Run Site PhpUnit Tests. Additional phpunit CLI options can be passed.
-   *
-   * @param array $args
-   *   Arguments to append to phpunit command.
-   *
-   * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
-   */
-  public function projectTestPhpunit(array $args) {
-    $proj_dir = Util::getProjectDirectory();
-    $phpunit_executable = $this->getPhpUnitExecutable();
-
-    $phpunitExec = $this->taskExec($phpunit_executable)
-      ->option('testsuite', 'Custom Test Suite')
-      ->dir("{$proj_dir}/docroot/modules/custom");
-
-    foreach ($args as $arg) {
-      $phpunitExec->arg($arg);
+        $cypress->run();
+        return $this->deleteTestUsers();
     }
 
-    return $phpunitExec->run();
-  }
+    /**
+     * Run Site PhpUnit Tests. Additional phpunit CLI options can be passed.
+     *
+     * @param array $args
+     *   Arguments to append to phpunit command.
+     *
+     * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
+     */
+    public function projectTestPhpunit(array $args)
+    {
+        $proj_dir = Util::getProjectDirectory();
+        $phpunit_executable = $this->getPhpUnitExecutable();
 
-  /**
-   * Determine path to PHPUnit executable.
-   */
-  private function getPhpUnitExecutable() {
-    $proj_dir = Util::getProjectDirectory();
+        $phpunitExec = $this->taskExec($phpunit_executable)
+            ->option('testsuite', 'Custom Test Suite')
+            ->dir("{$proj_dir}/docroot/modules/custom");
 
-    $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
+        foreach ($args as $arg) {
+            $phpunitExec->arg($arg);
+        }
 
-    if (!file_exists($phpunit_executable)) {
-      $this->taskExec("dktl installphpunit")->run();
-      $phpunit_executable = "phpunit";
+        return $phpunitExec->run();
     }
 
-    return $phpunit_executable;
-  }
+    /**
+     * Determine path to PHPUnit executable.
+     */
+    private function getPhpUnitExecutable()
+    {
+        $proj_dir = Util::getProjectDirectory();
 
-  /**
-   * Ensure current git branch is not in a detached state.
-   *
-   * @return bool
-   *   Flag for whether the current branch branch is detached.
-   */
-  private function inGitDetachedState($dkanDirPath) {
-    $output = [];
-    exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
-    return (isset($output[0]) && $output[0] == 'HEAD');
-  }
+        $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
 
+        if (!file_exists($phpunit_executable)) {
+            $this->taskExec("dktl installphpunit")->run();
+            $phpunit_executable = "phpunit";
+        }
+
+        return $phpunit_executable;
+    }
+
+    /**
+     * Ensure current git branch is not in a detached state.
+     *
+     * @return bool
+     *   Flag for whether the current branch branch is detached.
+     */
+    private function inGitDetachedState($dkanDirPath)
+    {
+        $output = [];
+        exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
+        return (isset($output[0]) && $output[0] == 'HEAD');
+    }
 }

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -10,94 +10,99 @@ use DkanTools\Util\TestUserTrait;
  *
  * @see http://robo.li/
  */
-class ProjectCommands extends Tasks
-{
-    use TestUserTrait;
+class ProjectCommands extends Tasks {
+  use TestUserTrait;
 
-    /**
-     * Run project cypress tests.
-     */
-    public function projectTestCypress(array $args)
-    {
+  /**
+   * Run project cypress tests.
+   */
+  public function projectTestCypress(array $args) {
 
-        $this->createTestUsers();
+    $this->createTestUsers();
 
-        $result = $this->taskExec("npm link ../../../../usr/local/bin/node_modules/cypress")
-            ->dir("src/tests")
-            ->run();
-        if ($result->getExitCode() != 0) {
-            $this->io()->error('Could not symlink package folder');
-            return $result;
-        }
-
-        $task = $this
-            ->taskExec('npm install --force')
-            ->dir("src/tests");
-        $result = $task->run();
-        if ($result->getExitCode() != 0) {
-            $this->io()->error('Could not insall test dependencies.');
-            return $result;
-        }
-        $this->io()->success('Installation of test dependencies successful.');
-        $config = file_exists("src/tests/cypress.json") ? '--config-file src/tests/cypress.json' : '';
-        $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run' . $config)
-            ->dir("src/tests");
-
-        foreach ($args as $arg) {
-            $cypress->arg($arg);
-        }
-
-        $cypress->run();
-        return $this->deleteTestUsers();
+    $result = $this->taskExec("npm link ../../../../usr/local/bin/node_modules/cypress")
+      ->dir("src/frontend")
+      ->run();
+    if ($result && $result->getExitCode() === 0) {
+      $this->io()->success(
+        'Successfully symlinked global cypress into frontend folder.'
+      );
+    }
+    else {
+      $this->io()->error('Could not symlink package folder');
+      return $result;
     }
 
-    /**
-     * Run Site PhpUnit Tests. Additional phpunit CLI options can be passed.
-     *
-     * @see   https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
-     * @param array $args
-     *   Arguments to append to phpunit command.
-     */
-    public function projectTestPhpunit(array $args)
-    {
-        $proj_dir = Util::getProjectDirectory();
-        $phpunit_executable = $this->getPhpUnitExecutable();
+    $task = $this
+      ->taskExec('npm install --force')
+      ->dir("src/tests");
+    $result = $task->run();
+    if ($result->getExitCode() != 0) {
+      $this->io()->error('Could not insall test dependencies.');
+      return $result;
+    }
+    $this->io()->success('Installation of test dependencies successful.');
+    $config = file_exists("src/tests/cypress.json") ? ' --config-file src/tests/cypress.json' : '';
+    $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run' . $config)
+      ->dir("src/tests");
 
-        $phpunitExec = $this->taskExec($phpunit_executable)
-            ->option('testsuite', 'Custom Test Suite')
-            ->dir("{$proj_dir}/docroot/modules/custom");
-
-        foreach ($args as $arg) {
-            $phpunitExec->arg($arg);
-        }
-
-        return $phpunitExec->run();
+    foreach ($args as $arg) {
+      $cypress->arg($arg);
     }
 
-    /**
-     *
-     */
-    private function getPhpUnitExecutable()
-    {
-        $proj_dir = Util::getProjectDirectory();
+    $cypress->run();
+    return $this->deleteTestUsers();
+  }
 
-        $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
+  /**
+   * Run Site PhpUnit Tests. Additional phpunit CLI options can be passed.
+   *
+   * @param array $args
+   *   Arguments to append to phpunit command.
+   *
+   * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
+   */
+  public function projectTestPhpunit(array $args) {
+    $proj_dir = Util::getProjectDirectory();
+    $phpunit_executable = $this->getPhpUnitExecutable();
 
-        if (!file_exists($phpunit_executable)) {
-            $this->taskExec("dktl installphpunit")->run();
-            $phpunit_executable = "phpunit";
-        }
+    $phpunitExec = $this->taskExec($phpunit_executable)
+      ->option('testsuite', 'Custom Test Suite')
+      ->dir("{$proj_dir}/docroot/modules/custom");
 
-        return $phpunit_executable;
+    foreach ($args as $arg) {
+      $phpunitExec->arg($arg);
     }
 
-    /**
-     *
-     */
-    private function inGitDetachedState($dkanDirPath)
-    {
-        $output = [];
-        exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
-        return (isset($output[0]) && $output[0] == 'HEAD');
+    return $phpunitExec->run();
+  }
+
+  /**
+   * Determine path to PHPUnit executable.
+   */
+  private function getPhpUnitExecutable() {
+    $proj_dir = Util::getProjectDirectory();
+
+    $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
+
+    if (!file_exists($phpunit_executable)) {
+      $this->taskExec("dktl installphpunit")->run();
+      $phpunit_executable = "phpunit";
     }
+
+    return $phpunit_executable;
+  }
+
+  /**
+   * Ensure current git branch is not in a detached state.
+   *
+   * @return bool
+   *   Flag for whether the current branch branch is detached.
+   */
+  private function inGitDetachedState($dkanDirPath) {
+    $output = [];
+    exec("cd {$dkanDirPath} && git rev-parse --abbrev-ref HEAD", $output);
+    return (isset($output[0]) && $output[0] == 'HEAD');
+  }
+
 }

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -60,6 +60,15 @@ class ProjectCommands extends \Robo\Tasks
         $this->deleteTestUsers();
     }
 
+     /**
+     * Create Test users.
+     */
+    public function projectCreateTestUsers(array $args)
+    {
+
+        $this->createTestUsers();
+    }
+
 
     /**
      * Run Site PhpUnit Tests. Additional phpunit CLI options can be passed.

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -2,17 +2,15 @@
 
 namespace DkanTools\Command;
 
-use DkanTools\Util\Util;
-use DkanTools\Util\TestUserTrait;
+use Robo\Tasks;
 
 /**
  * This project's console commands configuration for Robo task runner.
  *
  * @see http://robo.li/
  */
-class ProjectCommands extends \Robo\Tasks
+class ProjectCommands extends Tasks
 {
-    use TestUserTrait;
 
     /**
      * Run project cypress tests.
@@ -39,8 +37,8 @@ class ProjectCommands extends \Robo\Tasks
             return $result;
         }
         $this->io()->success('Installation of test dependencies successful.');
-        $config = file_exists( "src/tests/cypress.json") ? '--config-file src/tests/cypress.json' : '';
-        $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run {$config}')
+        $config = file_exists("src/tests/cypress.json") ? '--config-file src/tests/cypress.json' : '';
+        $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run' . $config)
             ->dir("src/tests");
 
         foreach ($args as $arg) {
@@ -60,7 +58,7 @@ class ProjectCommands extends \Robo\Tasks
         $this->deleteTestUsers();
     }
 
-     /**
+    /**
      * Create Test users.
      */
     public function projectCreateTestUsers(array $args)
@@ -69,12 +67,12 @@ class ProjectCommands extends \Robo\Tasks
         $this->createTestUsers();
     }
 
-
     /**
      * Run Site PhpUnit Tests. Additional phpunit CLI options can be passed.
      *
-     * @see https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
-     * @param array $args Arguments to append to phpunit command.
+     * @see   https://phpunit.de/manual/6.5/en/textui.html#textui.clioptions
+     * @param array $args
+     *   Arguments to append to phpunit command.
      */
     public function projectTestPhpunit(array $args)
     {
@@ -92,6 +90,9 @@ class ProjectCommands extends \Robo\Tasks
         return $phpunitExec->run();
     }
 
+    /**
+     *
+     */
     private function getPhpUnitExecutable()
     {
         $proj_dir = Util::getProjectDirectory();
@@ -106,6 +107,9 @@ class ProjectCommands extends \Robo\Tasks
         return $phpunit_executable;
     }
 
+    /**
+     *
+     */
     private function inGitDetachedState($dkanDirPath)
     {
         $output = [];

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -20,16 +20,7 @@ class ProjectCommands extends \Robo\Tasks
     public function projectTestCypress(array $args)
     {
 
-        if (is_dir('src/modules/test_accounts/')) {
-            $this->taskExecStack()
-            ->stopOnFail()
-            ->exec("dktl drush en test_accounts -y")
-            ->exec("dktl drush test-users:create")
-            ->run();
-        }else{
-            $this->apiUser();
-            $this->editorUser();
-        }
+        $this->createTestUsers();
 
         $result = $this->taskExec("npm link ../../../../usr/local/bin/node_modules/cypress")
             ->dir("src/tests")
@@ -48,8 +39,8 @@ class ProjectCommands extends \Robo\Tasks
             return $result;
         }
         $this->io()->success('Installation of test dependencies successful.');
-
-        $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run')
+        $config = file_exists( "src/tests/cypress.json") ? '--config-file src/tests/cypress.json' : '';
+        $cypress = $this->taskExec('CYPRESS_baseUrl="http://$DKTL_PROXY_DOMAIN" npx cypress run {$config}')
             ->dir("src/tests");
 
         foreach ($args as $arg) {
@@ -58,6 +49,16 @@ class ProjectCommands extends \Robo\Tasks
 
         return $cypress->run();
     }
+
+    /**
+     * Delete Test users.
+     */
+    public function projectDeleteTestUsers(array $args)
+    {
+
+        $this->deleteTestUsers();
+    }
+
 
     /**
      * Run Site PhpUnit Tests. Additional phpunit CLI options can be passed.

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -19,8 +19,17 @@ class ProjectCommands extends \Robo\Tasks
      */
     public function projectTestCypress(array $args)
     {
-        $this->apiUser();
-        $this->editorUser();
+
+        if (is_dir('src/modules/test_accounts/')) {
+            $this->taskExecStack()
+            ->stopOnFail()
+            ->exec("dktl drush en test_accounts -y")
+            ->exec("dktl drush test-users:create")
+            ->run();
+        }else{
+            $this->apiUser();
+            $this->editorUser();
+        }
 
         $result = $this->taskExec("npm link ../../../../usr/local/bin/node_modules/cypress")
             ->dir("src/tests")

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -3,6 +3,7 @@
 namespace DkanTools\Command;
 
 use Robo\Tasks;
+use DkanTools\Util\TestUserTrait;
 
 /**
  * This project's console commands configuration for Robo task runner.
@@ -11,6 +12,7 @@ use Robo\Tasks;
  */
 class ProjectCommands extends Tasks
 {
+    use TestUserTrait;
 
     /**
      * Run project cypress tests.
@@ -47,24 +49,6 @@ class ProjectCommands extends Tasks
 
         $cypress->run();
         return $this->deleteTestUsers();
-    }
-
-    /**
-     * Delete Test users.
-     */
-    public function projectDeleteTestUsers(array $args)
-    {
-
-        $this->deleteTestUsers();
-    }
-
-    /**
-     * Create Test users.
-     */
-    public function projectCreateTestUsers(array $args)
-    {
-
-        $this->createTestUsers();
     }
 
     /**

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -5,67 +5,63 @@ namespace DkanTools\Util;
 /**
  * Test User Trait.
  */
-trait TestUserTrait
-{
+trait TestUserTrait {
 
-    /**
-     * Private create user.
-     */
-    private function createTestUsers()
-    {
-        $people = $this->getUsers();
-        foreach ($people as $person) {
-            $name = $person->name;
-            $mail = $person->mail;
-            $role = $person->role;
-            $this->taskExecStack()
-                ->stopOnFail()
-                ->exec("dktl drush user:create $name --password=$name --mail=$mail")
-                ->exec("dktl drush user-add-role $role $name")
-                ->run();
-        }
+  /**
+   * Private create user.
+   */
+  private function createTestUsers() {
+    $people = $this->getUsers();
+    foreach ($people as $person) {
+      $name = $person->name;
+      $mail = $person->mail;
+      $role = $person->role;
+      $this->taskExecStack()
+        ->stopOnFail()
+        ->exec("dktl drush user:create $name --password=$name --mail=$mail")
+        ->exec("dktl drush user-add-role $role $name")
+        ->run();
     }
+  }
 
-    /**
-     * Get user.
-     */
-    protected function getUser($name)
-    {
-        if ($this->taskExecStack()->stopOnFail()->exec("dktl drush user:information $name")->run()->wasSuccessful()
-        ) {
-            return true;
-        } else {
-            return false;
-        }
+  /**
+   * Get user.
+   */
+  protected function userExists($name) {
+    if ($this->taskExecStack()->stopOnFail()->exec("dktl drush user:information $name")->run()->wasSuccessful()) {
+      return TRUE;
     }
+    else {
+      return FALSE;
+    }
+  }
 
-    /**
-     * Get user list.
-     */
-    protected function getUsers()
-    {
-        $dktlRoot = Util::getDktlDirectory();
-        $list = file_exists("testUsers.json") ? "testUsers.json" : $dktlRoot . '/testUsers.json';
-        $json = file_get_contents($list);
-        $user = json_decode($json);
-        return $user;
-    }
+  /**
+   * Get user list.
+   */
+  protected function getUsers() {
+    $dktlRoot = Util::getDktlDirectory();
+    $list = file_exists("testUsers.json") ? "testUsers.json" : $dktlRoot . '/testUsers.json';
+    $json = file_get_contents($list);
+    $user = json_decode($json);
+    return $user;
+  }
 
-    /**
-     * Protected delete user.
-     */
-    public function deleteTestUsers()
-    {
-        $people = $this->getUsers();
-        foreach ($people as $person) {
-            $name = $person->name;
-            $user = $this->getUser($name);
-            if ($user) {
-                $this->taskExecStack()
-                    ->stopOnFail()
-                    ->exec("dktl drush user:cancel --delete-content $name -y")
-                    ->run();
-            }
-        }
+  /**
+   * Protected delete user.
+   */
+  public function deleteTestUsers() {
+    $people = $this->getUsers();
+    foreach ($people as $person) {
+      $name = $person->name;
+      $user = $this->userExists($name);
+      if ($user) {
+        $this->taskExecStack()
+          ->stopOnFail()
+          ->exec("dktl drush user:cancel --delete-content $name -y")
+          ->run();
+      }
     }
+  }
+
 }

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -13,6 +13,7 @@ trait TestUserTrait
      */
     private function createTestUsers()
     {
+        $this->io()->say('Creating test users...');
         $people = $this->getUsers();
         foreach ($people as $person) {
             $name = $person->name;
@@ -27,9 +28,15 @@ trait TestUserTrait
     }
 
     /**
-     * Get user.
+     * Determine whether a user exists with the given username.
+     *
+     * @param $name
+     *   Username to search for.
+     *
+     * @return bool
+     *   Flag representing whether user exists.
      */
-    protected function userExists($name)
+    protected function userExists(string $name): bool
     {
         if ($this->taskExecStack()->stopOnFail()->exec("dktl drush user:information $name")->run()->wasSuccessful()) {
             return true;
@@ -55,6 +62,7 @@ trait TestUserTrait
      */
     public function deleteTestUsers()
     {
+        $this->io()->say('Deleting test users...');
         $people = $this->getUsers();
         foreach ($people as $person) {
             $name = $person->name;

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -2,8 +2,6 @@
 
 namespace DkanTools\Util;
 
-use DkanTools\Util\Util;
-
 /**
  * Test User Trait.
  */
@@ -17,27 +15,26 @@ trait TestUserTrait
     {
         $people = $this->getUsers();
         foreach ($people as $person) {
-            $name =$person->name;
-            $mail =$person->mail;
-            $role =$person->role;
+            $name = $person->name;
+            $mail = $person->mail;
+            $role = $person->role;
             $this->taskExecStack()
-            ->stopOnFail()
-            ->exec("dktl drush user:create $name --password=$name --mail=$mail")
-            ->exec("dktl drush user-add-role $role $name")
-            ->run();
+                ->stopOnFail()
+                ->exec("dktl drush user:create $name --password=$name --mail=$mail")
+                ->exec("dktl drush user-add-role $role $name")
+                ->run();
         }
     }
 
     /**
      * Get user.
      */
-    protected function getUser($name) {
-        if ($this->taskExecStack()
-            ->stopOnFail()
-            ->exec("dktl drush user:information $name")
-            ->run()->wasSuccessful()) {
-          return true;
-        }else{
+    protected function getUser($name)
+    {
+        if ($this->taskExecStack()->stopOnFail()->exec("dktl drush user:information $name")->run()->wasSuccessful()
+        ) {
+            return true;
+        } else {
             return false;
         }
     }
@@ -45,9 +42,10 @@ trait TestUserTrait
     /**
      * Get user list.
      */
-    protected function getUsers() {
+    protected function getUsers()
+    {
         $dktlRoot = Util::getDktlDirectory();
-        $list = file_exists( "testUsers.json") ? "testUsers.json" : $dktlRoot . '/testUsers.json';
+        $list = file_exists("testUsers.json") ? "testUsers.json" : $dktlRoot . '/testUsers.json';
         $json = file_get_contents($list);
         $user = json_decode($json);
         return $user;
@@ -56,17 +54,18 @@ trait TestUserTrait
     /**
      * Protected delete user.
      */
-    public function deleteTestUsers() {
-    $people = $this->getUsers();
-    foreach ($people as $person) {
-        $name = $person->name;
-        $user = $this->getUser($name);
-      if ($user) {
-         $this->taskExecStack()
-            ->stopOnFail()
-            ->exec("dktl drush user:cancel --delete-content $name -y")
-            ->run();
-      }
+    public function deleteTestUsers()
+    {
+        $people = $this->getUsers();
+        foreach ($people as $person) {
+            $name = $person->name;
+            $user = $this->getUser($name);
+            if ($user) {
+                $this->taskExecStack()
+                    ->stopOnFail()
+                    ->exec("dktl drush user:cancel --delete-content $name -y")
+                    ->run();
+            }
+        }
     }
-  }
 }

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -32,9 +32,9 @@ trait TestUserTrait
     protected function userExists($name)
     {
         if ($this->taskExecStack()->stopOnFail()->exec("dktl drush user:information $name")->run()->wasSuccessful()) {
-            return TRUE;
+            return true;
         } else {
-            return FALSE;
+            return false;
         }
     }
 

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -5,63 +5,66 @@ namespace DkanTools\Util;
 /**
  * Test User Trait.
  */
-trait TestUserTrait {
+trait TestUserTrait
+{
 
-  /**
-   * Private create user.
-   */
-  private function createTestUsers() {
-    $people = $this->getUsers();
-    foreach ($people as $person) {
-      $name = $person->name;
-      $mail = $person->mail;
-      $role = $person->role;
-      $this->taskExecStack()
-        ->stopOnFail()
-        ->exec("dktl drush user:create $name --password=$name --mail=$mail")
-        ->exec("dktl drush user-add-role $role $name")
-        ->run();
+    /**
+     * Private create user.
+     */
+    private function createTestUsers()
+    {
+        $people = $this->getUsers();
+        foreach ($people as $person) {
+            $name = $person->name;
+            $mail = $person->mail;
+            $role = $person->role;
+            $this->taskExecStack()
+                ->stopOnFail()
+                ->exec("dktl drush user:create $name --password=$name --mail=$mail")
+                ->exec("dktl drush user-add-role $role $name")
+                ->run();
+        }
     }
-  }
 
-  /**
-   * Get user.
-   */
-  protected function userExists($name) {
-    if ($this->taskExecStack()->stopOnFail()->exec("dktl drush user:information $name")->run()->wasSuccessful()) {
-      return TRUE;
+    /**
+     * Get user.
+     */
+    protected function userExists($name)
+    {
+        if ($this->taskExecStack()->stopOnFail()->exec("dktl drush user:information $name")->run()->wasSuccessful()) {
+            return TRUE;
+        } else {
+            return FALSE;
+        }
     }
-    else {
-      return FALSE;
+
+    /**
+     * Get user list.
+     */
+    protected function getUsers()
+    {
+        $dktlRoot = Util::getDktlDirectory();
+        $list = file_exists("testUsers.json") ? "testUsers.json" : $dktlRoot . '/testUsers.json';
+        $json = file_get_contents($list);
+        $user = json_decode($json);
+        return $user;
     }
-  }
 
-  /**
-   * Get user list.
-   */
-  protected function getUsers() {
-    $dktlRoot = Util::getDktlDirectory();
-    $list = file_exists("testUsers.json") ? "testUsers.json" : $dktlRoot . '/testUsers.json';
-    $json = file_get_contents($list);
-    $user = json_decode($json);
-    return $user;
-  }
-
-  /**
-   * Protected delete user.
-   */
-  public function deleteTestUsers() {
-    $people = $this->getUsers();
-    foreach ($people as $person) {
-      $name = $person->name;
-      $user = $this->userExists($name);
-      if ($user) {
-        $this->taskExecStack()
-          ->stopOnFail()
-          ->exec("dktl drush user:cancel --delete-content $name -y")
-          ->run();
-      }
+    /**
+     * Protected delete user.
+     */
+    public function deleteTestUsers()
+    {
+        $people = $this->getUsers();
+        foreach ($people as $person) {
+            $name = $person->name;
+            $user = $this->userExists($name);
+            if ($user) {
+                $this->taskExecStack()
+                    ->stopOnFail()
+                    ->exec("dktl drush user:cancel --delete-content $name -y")
+                    ->run();
+            }
+        }
     }
-  }
-
 }

--- a/testUsers.json
+++ b/testUsers.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "testuser",
+    "mail": "testuser@test.com",
+    "role": "api_user"
+  },
+  {
+    "name": "testeditor",
+    "email": "testeditor@test.com",
+    "role": "administrator"
+  }
+]

--- a/testUsers.json
+++ b/testUsers.json
@@ -1,12 +1,12 @@
 [
   {
-    "name": "testuser",
-    "mail": "testuser@test.com",
+    "name": "testapiuser",
+    "mail": "testapiuser@test.com",
     "role": "api_user"
   },
   {
-    "name": "testeditor",
-    "email": "testeditor@test.com",
+    "name": "testadmin",
+    "mail": "testadmin@test.com",
     "role": "administrator"
   }
 ]


### PR DESCRIPTION
This pr revamps the testing trait to create test users based on a testUsers.json file added to the root of the project/src folder. If there isn't a testUsers.json file in the project folder the testUsers.json file in the dktl root folder will be used.

The ProjectCommands.php was also updated to create the test users before cypress runs then delete the test users after cypress tests are completed.

There are also 2 new commands added if you want to create/delete test users without running cypress. They are:
`dkan:create-test-users` alias `qauc`
`dkan:delete-test-users` alias `qaud`