### PR TITLE
Return actual status from dkan:test-phpunit

### DIFF
--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -70,8 +70,9 @@ class DkanCommands extends \Robo\Tasks
             $cypress->arg($arg);
         }
 
-        $cypress->run();
+        $result = $cypress->run();
         $this->deleteTestUsers();
+        return $result;
     }
 
     /**

--- a/src/Command/DkanCommands.php
+++ b/src/Command/DkanCommands.php
@@ -112,8 +112,9 @@ class DkanCommands extends \Robo\Tasks
             $phpunitExec->arg($arg);
         }
 
-        $phpunitExec->run();
+        $result = $phpunitExec->run();
         $this->deleteTestUsers();
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Previously we returned nothing so circleCI would not fail the build if phpunit failed.