### PR TITLE
Fixes some issues with project:test-phpunit

### DIFF
--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -112,12 +112,9 @@ class ProjectCommands extends Tasks
      */
     public function projectTestPhpunit(array $args)
     {
-        $proj_dir = Util::getProjectDirectory();
         $phpunit_executable = $this->getPhpUnitExecutable();
 
-        $phpunitExec = $this->taskExec($phpunit_executable)
-            ->option('testsuite', 'Custom Test Suite')
-            ->dir("{$proj_dir}/docroot/modules/custom");
+        $phpunitExec = $this->taskExec($phpunit_executable);
 
         foreach ($args as $arg) {
             $phpunitExec->arg($arg);
@@ -131,9 +128,9 @@ class ProjectCommands extends Tasks
      */
     private function getPhpUnitExecutable()
     {
-        $proj_dir = Util::getProjectDirectory();
+        // $proj_dir = Util::getProjectDirectory();
 
-        $phpunit_executable = $phpunit_executable = "{$proj_dir}/vendor/bin/phpunit";
+        $phpunit_executable = $phpunit_executable = "vendor/bin/phpunit";
 
         if (!file_exists($phpunit_executable)) {
             $this->taskExec("dktl installphpunit")->run();

--- a/src/Command/ProjectCommands.php
+++ b/src/Command/ProjectCommands.php
@@ -128,8 +128,6 @@ class ProjectCommands extends Tasks
      */
     private function getPhpUnitExecutable()
     {
-        // $proj_dir = Util::getProjectDirectory();
-
         $phpunit_executable = $phpunit_executable = "vendor/bin/phpunit";
 
         if (!file_exists($phpunit_executable)) {

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -26,12 +26,6 @@ testUninitialized() {
     assertContains "${result}" "DKTL is running outside of a DKTL project."
 }
 
-testDktlInitWithBadParameter() {
-    result=`dktl init --dkan=foobar`
-    assertContains "${result}" "Could not parse version constraint foobar"
-    rm -rf composer.* dktl.yml docrot src
-}
-
 testDktlInit() {
     result=`dktl init`
     assertContains "${result}" 'Composer project created'


### PR DESCRIPTION
The current command assumes a particular testsuite name. This simply runs phpunit in the project root, assuming all is defined as needed in phpunit.xml or else passed as an option to the command.