### PR TITLE
Specify project root for test user creation

### DIFF
--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -12,7 +12,7 @@ class FrontendCommands extends Tasks
 
     const FRONTEND_DIR = 'src/frontend';
     const FRONTEND_VCS_URL = 'https://github.com/GetDKAN/data-catalog-app/';
-    const FRONTEND_VCS_REF = '1.1.0';
+    const FRONTEND_VCS_REF = 'master';
     const FRONTEND_THEME = 'getdkan/dkan_js_frontend_bartik';
 
 

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -261,9 +261,11 @@ class FrontendCommands extends Tasks
     {
         if (!file_exists(self::FRONTEND_DIR)) {
             $this->frontendGet();
+            $this->io()->success('Frontend directory found.');
         }
         if (!file_exists("docroot/frontend")) {
             $this->frontendLink();
+            $this->io()->success('Frontend directory symlinked.');
         }
 
         // Override GATSBY_API_URL with our own proxied domain.

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -261,7 +261,7 @@ class FrontendCommands extends Tasks
     {
         // Override GATSBY_API_URL with our own proxied domain.
         $task = $this
-            ->taskExec('npm run build --force')
+            ->taskExec('npm run build')
             ->dir("src/frontend");
         $result = $task->run();
         if ($result->getExitCode() != 0) {

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -12,7 +12,7 @@ class FrontendCommands extends Tasks
 
     const FRONTEND_DIR = 'src/frontend';
     const FRONTEND_VCS_URL = 'https://github.com/GetDKAN/data-catalog-app/';
-    const FRONTEND_VCS_REF = 'cypress-update-8.7.0';
+    const FRONTEND_VCS_REF = '1.1.0';
     const FRONTEND_THEME = 'getdkan/dkan_js_frontend_bartik';
 
 

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -259,6 +259,13 @@ class FrontendCommands extends Tasks
      */
     public function frontendBuild()
     {
+        if (!file_exists(self::FRONTEND_DIR)) {
+            $this->frontendGet();
+        }
+        if (!file_exists("docroot/frontend")) {
+            $this->frontendLink();
+        }
+
         // Override GATSBY_API_URL with our own proxied domain.
         $task = $this
             ->taskExec('npm run build')

--- a/src/Command/FrontendCommands.php
+++ b/src/Command/FrontendCommands.php
@@ -259,18 +259,9 @@ class FrontendCommands extends Tasks
      */
     public function frontendBuild()
     {
-        if (!file_exists(self::FRONTEND_DIR)) {
-            $this->frontendGet();
-            $this->io()->success('Frontend directory found.');
-        }
-        if (!file_exists("docroot/frontend")) {
-            $this->frontendLink();
-            $this->io()->success('Frontend directory symlinked.');
-        }
-
         // Override GATSBY_API_URL with our own proxied domain.
         $task = $this
-            ->taskExec('npm run build')
+            ->taskExec('CI=false npm run build')
             ->dir("src/frontend");
         $result = $task->run();
         if ($result->getExitCode() != 0) {

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -23,7 +23,7 @@ class InitCommands extends \Robo\Tasks
      *   If no version constraint is provided via the --dkan option, dktl will
      *   attempt to generate one based on the current git branch in "dkan".
     */
-    public function init($opts = ['dkan' => NULL, 'dkan-local' => FALSE])
+    public function init($opts = ['dkan' => null, 'dkan-local' => false])
     {
         $this->initConfig();
         $this->initSrc();
@@ -217,7 +217,7 @@ class InitCommands extends \Robo\Tasks
      *
      * @return [type]
      */
-    public function initDkan(string $version = NULL)
+    public function initDkan(string $version = null)
     {
         $this->io()->section('Adding DKAN project dependency.');
         $this->taskComposerRequire()

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -23,7 +23,7 @@ class InitCommands extends \Robo\Tasks
      *   If no version constraint is provided via the --dkan option, dktl will
      *   attempt to generate one based on the current git branch in "dkan".
     */
-    public function init($opts = ['dkan' => '2.x-dev', 'dkan-local' => FALSE])
+    public function init($opts = ['dkan' => NULL, 'dkan-local' => FALSE])
     {
         $this->initConfig();
         $this->initSrc();
@@ -217,7 +217,7 @@ class InitCommands extends \Robo\Tasks
      *
      * @return [type]
      */
-    public function initDkan(string $version = "2.x-dev")
+    public function initDkan(string $version = NULL)
     {
         $this->io()->section('Adding DKAN project dependency.');
         $this->taskComposerRequire()

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -23,7 +23,7 @@ class InitCommands extends \Robo\Tasks
      *   If no version constraint is provided via the --dkan option, dktl will
      *   attempt to generate one based on the current git branch in "dkan".
     */
-    public function init($opts = ['dkan' => null, 'dkan-local' => false])
+    public function init($opts = ['dkan' => '2.x-dev', 'dkan-local' => FALSE])
     {
         $this->initConfig();
         $this->initSrc();
@@ -217,7 +217,7 @@ class InitCommands extends \Robo\Tasks
      *
      * @return [type]
      */
-    public function initDkan(string $version = null)
+    public function initDkan(string $version = "2.x-dev")
     {
         $this->io()->section('Adding DKAN project dependency.');
         $this->taskComposerRequire()

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -217,7 +217,7 @@ class InitCommands extends \Robo\Tasks
      *
      * @return [type]
      */
-    public function initDkan(string $version = null)
+    public function initDkan(string $version = "dev-frontend-update")
     {
         $this->io()->section('Adding DKAN project dependency.');
         $this->taskComposerRequire()

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -23,7 +23,7 @@ class InitCommands extends \Robo\Tasks
      *   If no version constraint is provided via the --dkan option, dktl will
      *   attempt to generate one based on the current git branch in "dkan".
     */
-    public function init($opts = ['dkan' => null, 'dkan-local' => false])
+    public function init($opts = ['dkan' => 'dev-frontend-update', 'dkan-local' => false])
     {
         $this->initConfig();
         $this->initSrc();

--- a/src/Command/InitCommands.php
+++ b/src/Command/InitCommands.php
@@ -23,7 +23,7 @@ class InitCommands extends \Robo\Tasks
      *   If no version constraint is provided via the --dkan option, dktl will
      *   attempt to generate one based on the current git branch in "dkan".
     */
-    public function init($opts = ['dkan' => 'dev-frontend-update', 'dkan-local' => false])
+    public function init($opts = ['dkan' => null, 'dkan-local' => false])
     {
         $this->initConfig();
         $this->initSrc();
@@ -217,7 +217,7 @@ class InitCommands extends \Robo\Tasks
      *
      * @return [type]
      */
-    public function initDkan(string $version = "dev-frontend-update")
+    public function initDkan(string $version = null)
     {
         $this->io()->section('Adding DKAN project dependency.');
         $this->taskComposerRequire()

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -52,7 +52,9 @@ trait TestUserTrait
     {
         $dktlRoot = Util::getDktlDirectory();
         $projectRoot = Util::getProjectDirectory();
-        $list = file_exists($projectRoot . "testUsers.json") ? $projectRoot . "testUsers.json" : $dktlRoot . '/testUsers.json';
+        $list = file_exists($projectRoot . "/testUsers.json")
+          ? $projectRoot . "/testUsers.json"
+          : $dktlRoot . '/testUsers.json';
         $json = file_get_contents($list);
         $user = json_decode($json);
         return $user;

--- a/src/Util/TestUserTrait.php
+++ b/src/Util/TestUserTrait.php
@@ -51,7 +51,8 @@ trait TestUserTrait
     protected function getUsers()
     {
         $dktlRoot = Util::getDktlDirectory();
-        $list = file_exists("testUsers.json") ? "testUsers.json" : $dktlRoot . '/testUsers.json';
+        $projectRoot = Util::getProjectDirectory();
+        $list = file_exists($projectRoot . "testUsers.json") ? $projectRoot . "testUsers.json" : $dktlRoot . '/testUsers.json';
         $json = file_get_contents($list);
         $user = json_decode($json);
         return $user;

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -86,40 +86,40 @@ testFrontEnd() {
     assertContains "${result}" "package.json"
 
     result=`dktl frontend:build`
-    assertContains "${result}" "The project was built assuming it is hosted at /."
+    assertContains "${result}" "The project was built assuming it is hosted at /frontend/build/."
 
     result=`curl $url`
     assertContains "${result}" '<div id="root">'
 }
 
-# testBringDown() {
-#     wait
-#     dktl down
+testBringDown() {
+    wait
+    dktl down
 
-#     result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+    result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
 
-#     result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
+    result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
 
-#     result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
-# }
+    result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
+}
 
-# oneTimeTearDown() {
-#     containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
-#     echo $containers
-#     if [ ! -z "$containers" ]; then
-#         echo "$containers" | xargs docker stop | xargs docker rm -v
-#         docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
-#         docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
-#     fi
-#     if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
-#         rm -rf $DKTL_TEST_PROJECT_DIR
-#     fi
-# }
+oneTimeTearDown() {
+    containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
+    echo $containers
+    if [ ! -z "$containers" ]; then
+        echo "$containers" | xargs docker stop | xargs docker rm -v
+        docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
+        docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
+    fi
+    if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
+        rm -rf $DKTL_TEST_PROJECT_DIR
+    fi
+}
 
 # Load shUnit2.
 . ./shunit2/shunit2

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -88,37 +88,38 @@ testFrontEnd() {
     result=`dktl frontend:build`
     assertContains "${result}" "The project was built assuming it is hosted at /."
 
+    echo $url
     result=`curl $url`
     assertContains "${result}" '<div id="root">'
 }
 
-testBringDown() {
-    dktl down
+# testBringDown() {
+#     dktl down
 
-    result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+#     result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
 
-    result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
+#     result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
 
-    result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
-}
+#     result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
+# }
 
-oneTimeTearDown() {
-    containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
-    echo $containers
-    if [ ! -z "$containers" ]; then
-        echo "$containers" | xargs docker stop | xargs docker rm -v
-        docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
-        docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
-    fi
-    if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
-        rm -rf $DKTL_TEST_PROJECT_DIR
-    fi
-}
+# oneTimeTearDown() {
+#     containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
+#     echo $containers
+#     if [ ! -z "$containers" ]; then
+#         echo "$containers" | xargs docker stop | xargs docker rm -v
+#         docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
+#         docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
+#     fi
+#     if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
+#         rm -rf $DKTL_TEST_PROJECT_DIR
+#     fi
+# }
 
 # Load shUnit2.
 . ./shunit2/shunit2

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -92,33 +92,33 @@ testFrontEnd() {
     assertContains "${result}" '<div id="root">'
 }
 
-# testBringDown() {
-#     dktl down
+testBringDown() {
+    dktl down
 
-#     result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+    result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
 
-#     result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
+    result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
 
-#     result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
-# }
+    result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
+}
 
-# oneTimeTearDown() {
-#     containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
-#     echo $containers
-#     if [ ! -z "$containers" ]; then
-#         echo "$containers" | xargs docker stop | xargs docker rm -v
-#         docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
-#         docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
-#     fi
-#     if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
-#         rm -rf $DKTL_TEST_PROJECT_DIR
-#     fi
-# }
+oneTimeTearDown() {
+    containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
+    echo $containers
+    if [ ! -z "$containers" ]; then
+        echo "$containers" | xargs docker stop | xargs docker rm -v
+        docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
+        docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
+    fi
+    if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
+        rm -rf $DKTL_TEST_PROJECT_DIR
+    fi
+}
 
 # Load shUnit2.
 . ./shunit2/shunit2

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -86,7 +86,7 @@ testFrontEnd() {
     assertContains "${result}" "package.json"
 
     result=`dktl frontend:build`
-    assertContains "${result}" "The project was built assuming it is hosted at /frontend/build/."
+    assertContains "${result}" "The project was built assuming it is hosted at /."
 
     result=`curl $url`
     assertContains "${result}" '<div id="root">'

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -92,34 +92,34 @@ testFrontEnd() {
     assertContains "${result}" '<div id="root">'
 }
 
-testBringDown() {
-    wait
-    dktl down
+# testBringDown() {
+#     wait
+#     dktl down
 
-    result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+#     result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
 
-    result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
+#     result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
 
-    result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
-}
+#     result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
+# }
 
-oneTimeTearDown() {
-    containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
-    echo $containers
-    if [ ! -z "$containers" ]; then
-        echo "$containers" | xargs docker stop | xargs docker rm -v
-        docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
-        docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
-    fi
-    if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
-        rm -rf $DKTL_TEST_PROJECT_DIR
-    fi
-}
+# oneTimeTearDown() {
+#     containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
+#     echo $containers
+#     if [ ! -z "$containers" ]; then
+#         echo "$containers" | xargs docker stop | xargs docker rm -v
+#         docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
+#         docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
+#     fi
+#     if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
+#         rm -rf $DKTL_TEST_PROJECT_DIR
+#     fi
+# }
 
 # Load shUnit2.
 . ./shunit2/shunit2

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -93,7 +93,7 @@ testFrontEnd() {
 }
 
 testBringDown() {
-    wait -f
+    wait
     dktl down
 
     result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -92,33 +92,33 @@ testFrontEnd() {
     assertContains "${result}" '<div id="root">'
 }
 
-testBringDown() {
-    dktl down
+# testBringDown() {
+#     dktl down
 
-    result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+#     result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
 
-    result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
+#     result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
 
-    result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
-}
+#     result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
+# }
 
-oneTimeTearDown() {
-    containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
-    echo $containers
-    if [ ! -z "$containers" ]; then
-        echo "$containers" | xargs docker stop | xargs docker rm -v
-        docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
-        docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
-    fi
-    if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
-        rm -rf $DKTL_TEST_PROJECT_DIR
-    fi
-}
+# oneTimeTearDown() {
+#     containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
+#     echo $containers
+#     if [ ! -z "$containers" ]; then
+#         echo "$containers" | xargs docker stop | xargs docker rm -v
+#         docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
+#         docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
+#     fi
+#     if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
+#         rm -rf $DKTL_TEST_PROJECT_DIR
+#     fi
+# }
 
 # Load shUnit2.
 . ./shunit2/shunit2

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -92,34 +92,34 @@ testFrontEnd() {
     assertContains "${result}" '<div id="root">'
 }
 
-# testBringDown() {
-#     wait
-#     dktl down
+testBringDown() {
+    wait
+    dktl down
 
-#     result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+    result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
 
-#     result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
+    result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
 
-#     result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
-# }
+    result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
+}
 
-# oneTimeTearDown() {
-#     containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
-#     echo $containers
-#     if [ ! -z "$containers" ]; then
-#         echo "$containers" | xargs docker stop | xargs docker rm -v
-#         docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
-#         docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
-#     fi
-#     if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
-#         rm -rf $DKTL_TEST_PROJECT_DIR
-#     fi
-# }
+oneTimeTearDown() {
+    containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
+    echo $containers
+    if [ ! -z "$containers" ]; then
+        echo "$containers" | xargs docker stop | xargs docker rm -v
+        docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
+        docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
+    fi
+    if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
+        rm -rf $DKTL_TEST_PROJECT_DIR
+    fi
+}
 
 # Load shUnit2.
 . ./shunit2/shunit2

--- a/tests/dktl_test.sh
+++ b/tests/dktl_test.sh
@@ -88,38 +88,38 @@ testFrontEnd() {
     result=`dktl frontend:build`
     assertContains "${result}" "The project was built assuming it is hosted at /."
 
-    echo $url
     result=`curl $url`
     assertContains "${result}" '<div id="root">'
 }
 
-# testBringDown() {
-#     dktl down
+testBringDown() {
+    wait -f
+    dktl down
 
-#     result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+    result=`docker ps --all --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_cli_1"
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_web_1"
 
-#     result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
+    result=`docker volume ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_composer"
 
-#     result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
-#     assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
-# }
+    result=`docker network ls --filter "name=${DKTL_TEST_PROJECT_NAME}"`
+    assertNotContains "${result}" "${DKTL_TEST_PROJECT_NAME}_default"
+}
 
-# oneTimeTearDown() {
-#     containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
-#     echo $containers
-#     if [ ! -z "$containers" ]; then
-#         echo "$containers" | xargs docker stop | xargs docker rm -v
-#         docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
-#         docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
-#     fi
-#     if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
-#         rm -rf $DKTL_TEST_PROJECT_DIR
-#     fi
-# }
+oneTimeTearDown() {
+    containers=`docker ps --filter name="${DKTL_TEST_PROJECT_NAME}*" -aq`
+    echo $containers
+    if [ ! -z "$containers" ]; then
+        echo "$containers" | xargs docker stop | xargs docker rm -v
+        docker network disconnect "${DKTL_TEST_PROJECT_NAME}_default" dktl-proxy
+        docker network rm "${DKTL_TEST_PROJECT_NAME}_default"
+    fi
+    if [ -d "${DKTL_TEST_PROJECT_DIR}" ]; then
+        rm -rf $DKTL_TEST_PROJECT_DIR
+    fi
+}
 
 # Load shUnit2.
 . ./shunit2/shunit2


### PR DESCRIPTION
Cypress tests are failing because the frontend:build is failing
```
npm run build

> @civicactions/data-catalog-app@1.0.3 build
> react-scripts build

Creating an optimized production build...
Failed to compile.

./src/theme/index.scss
Error: Node Sass does not yet support your current environment: Linux 64-bit with Unsupported runtime (93)
For more information on which environments are supported please see:
https://github.com/sass/node-sass/releases/tag/v4.14.1
```
Switching to a version of [data-catalog-app](https://github.com/GetDKAN/data-catalog-app/pull/105) that uses sass rather than node-sass, allows the build to complete

But--- then the tests fail due to this
```
Treating warnings as errors because process.env.CI = true.
Most CI servers set it automatically.
```
So adding the CI=false allows test to not fail on warnings, AND adding `wait` so that the final test can finish before the tear down starts.